### PR TITLE
Helmfile.d - Add stable/grafana

### DIFF
--- a/helmfile.d/0410.kube-prometheus.yaml
+++ b/helmfile.d/0410.kube-prometheus.yaml
@@ -1,7 +1,6 @@
 helmDefaults:
   args:
     - "--wait"
-    - "--recreate-pods"
     - "--timeout=600" 
     - "--force"
     - "--reset-values"
@@ -40,7 +39,8 @@ releases:
   chart: "coreos-stable/kube-prometheus"
   version: "0.0.66"
   values:
-    - "values/kube-prometheus.grafana.dashboards.yaml"
+    ### Optional: KUBE_PROMETHEUS_EXTERNAL_VALUES_FILE;
+    - '{{ env "KUBE_PROMETHEUS_EXTERNAL_VALUES_FILE" | default "values/kube-prometheus.grafana.dashboards.yaml" }}'
     - global:
         rbacEnable: false
       deployExporterNode: true

--- a/helmfile.d/0410.kube-prometheus.yaml
+++ b/helmfile.d/0410.kube-prometheus.yaml
@@ -40,6 +40,7 @@ releases:
   chart: "coreos-stable/kube-prometheus"
   version: "0.0.66"
   values:
+    - "values/kube-prometheus.grafana.dashboards.yaml"
     - global:
         rbacEnable: false
       deployExporterNode: true

--- a/helmfile.d/0420.grafana.yaml
+++ b/helmfile.d/0420.grafana.yaml
@@ -34,18 +34,13 @@ releases:
         size: 10Gi
         accessModes:
           - ReadWriteOnce
-      sidecar:
-        dashboards:
-          enabled: true
-        datasources:
-          enabled: true
       datasources:
         datasources.yaml:
           apiVersion: 1
           datasources:
             - name: Prometheus
               type: prometheus
-              url: 'http://kube-prometheus-prometheus'
+              url: 'http://kube-prometheus-prometheus:9090'
               access: proxy
               isDefault: true
       dashboardProviders:

--- a/helmfile.d/0420.grafana.yaml
+++ b/helmfile.d/0420.grafana.yaml
@@ -1,7 +1,6 @@
 helmDefaults:
   args:
     - "--wait"
-    - "--recreate-pods"
     - "--timeout=600" 
     - "--force"
     - "--reset-values"

--- a/helmfile.d/0420.grafana.yaml
+++ b/helmfile.d/0420.grafana.yaml
@@ -1,0 +1,71 @@
+helmDefaults:
+  args:
+    - "--wait"
+    - "--recreate-pods"
+    - "--timeout=600" 
+    - "--force"
+    - "--reset-values"
+
+repositories:
+# Stable repo of official helm charts
+- name: "stable"
+  url: "https://kubernetes-charts.storage.googleapis.com"
+
+releases:
+
+#######################################################################################
+## Grafana                                                                           ##
+#######################################################################################
+
+- name: "grafana"
+  namespace: "monitoring"
+  labels:
+    chart: "grafana"
+    component: "monitoring"
+    namespace: "monitoring"
+    vendor: "kubernetes"
+    default: "true"
+  chart: "stable/grafana"
+  version: "1.12.0"
+  values:
+    - "values/grafana.dashboards.yaml"
+    - persistence:
+        enabled: true
+        size: 10Gi
+        accessModes:
+          - ReadWriteOnce
+      sidecar:
+        dashboards:
+          enabled: true
+        datasources:
+          enabled: true
+      datasources:
+        datasources.yaml:
+          apiVersion: 1
+          datasources:
+            - name: Prometheus
+              type: prometheus
+              url: 'http://kube-prometheus-prometheus'
+              access: proxy
+              isDefault: true
+      dashboardProviders:
+        dashboardproviders.yaml:
+          apiVersion: 1
+          providers:
+          - name: 'default'
+            orgId: 1
+            folder: ''
+            type: file
+            disableDeletion: false
+            editable: true
+            options:
+              path: /var/lib/grafana/dashboards/default
+      dashboards:
+        default: {}
+      resources:
+        limits:
+          cpu: "50m"
+          memory: "64Mi"
+        requests:
+          cpu: "10m"
+          memory: "64Mi"

--- a/helmfile.d/0420.grafana.yaml
+++ b/helmfile.d/0420.grafana.yaml
@@ -24,14 +24,16 @@ releases:
     component: "monitoring"
     namespace: "monitoring"
     vendor: "kubernetes"
-    default: "true"
+    default: "false"
   chart: "stable/grafana"
   version: "1.12.0"
   values:
-    - "values/grafana.dashboards.yaml"
+    ### Optional: GRAFANA_EXTERNAL_VALUES_FILE;
+    - '{{ env "GRAFANA_EXTERNAL_VALUES_FILE" | default "values/grafana.dashboards.yaml" }}'
     - persistence:
         enabled: true
-        size: 10Gi
+        ### Optional: GRAFANA_PERSISTENCE_SIZE;
+        size: '{{ env "GRAFANA_PERSISTENCE_SIZE" | default "10Gi" }}'
         accessModes:
           - ReadWriteOnce
       datasources:
@@ -40,7 +42,8 @@ releases:
           datasources:
             - name: Prometheus
               type: prometheus
-              url: 'http://kube-prometheus-prometheus:9090'
+              ### Optional: GRAFANA_PROMETHEUS_ENDPOINT;
+              url: '{{ env "GRAFANA_PROMETHEUS_ENDPOINT" | default "http://kube-prometheus-prometheus:9090" }}'
               access: proxy
               isDefault: true
       dashboardProviders:
@@ -64,3 +67,28 @@ releases:
         requests:
           cpu: "10m"
           memory: "64Mi"
+      serviceAccount:
+        ### Optional: GRAFANA_SERVICE_ACCOUT_CREATE;
+        create: '{{ env "GRAFANA_SERVICE_ACCOUT_CREATE" | default "true" }}'
+        ### Optional: GRAFANA_SERVICE_ACCOUT_NAME;
+        name: '{{ env "GRAFANA_SERVICE_ACCOUT_NAME" | default "grafana" }}'
+      ingress:
+        ### Optional: GRAFANA_INGRESS_ENABLED;
+        enabled: '{{ env "GRAFANA_INGRESS_ENABLED" | default "false" }}'
+        annotations:
+          kubernetes.io/ingress.class: "nginx"
+          kubernetes.io/tls-acme: "true"
+          external-dns.alpha.kubernetes.io/ttl: "60"
+          ### Required: GRAFANA_INGRESS;
+          external-dns.alpha.kubernetes.io/target: '{{ env "GRAFANA_INGRESS" }}'
+          ### Required: GRAFANA_HOSTNAME;
+          external-dns.alpha.kubernetes.io/hostname: '{{ env "GRAFANA_HOSTNAME" }}'
+        hosts:
+          ### Required: GRAFANA_HOSTNAME;
+          - '{{ env "GRAFANA_HOSTNAME" }}'
+        tls:
+            ### Optional: GRAFANA_SECRET_NAME;
+          - secretName: '{{ env "GRAFANA_SECRET_NAME" | default "grafana-server-tls" }}'
+            hosts:
+              ### Required: GRAFANA_HOSTNAME;
+              - '{{ env "GRAFANA_HOSTNAME" }}'

--- a/helmfile.d/values/grafana.dashboards.yaml
+++ b/helmfile.d/values/grafana.dashboards.yaml
@@ -1,0 +1,13 @@
+# dashboards:
+#   default:
+#     kubernetes-cluster-monitoring:
+#       gnetId: 315А
+#       revision: 3
+#       datasource: Prometheus
+#     some-dashboard:
+#       json: |-
+#         {
+
+#         }
+#     local-dashboard:
+#       url: https://example.com/repository/test.json

--- a/helmfile.d/values/kube-prometheus.grafana.dashboards.yaml
+++ b/helmfile.d/values/kube-prometheus.grafana.dashboards.yaml
@@ -1,0 +1,15 @@
+# grafana:
+#   serverDashboardFiles:
+#     unique_file_name-dashboard.json: |-
+#       {
+#         "dashboard": {...},
+#         "inputs": [
+#           {
+#               "name": "DS_PROMETHEUS",
+#               "pluginId": "prometheus",
+#               "type": "datasource",
+#               "value": "prometheus"
+#           }
+#         ],
+#         "overwrite": true
+#       }


### PR DESCRIPTION
## what
* add helmfile with stable/grafana chart
* add values with examples how to add custom dashboards (for stable/grafana and kube-prometheus/grafana)
 
## why
* Dashboards import is unclear with default kube-prometheus grafana deployment