### PR TITLE
[cert-manager] Add `kube-lego` alternative

### DIFF
--- a/helmfile.d/0120.cert-manager.yaml
+++ b/helmfile.d/0120.cert-manager.yaml
@@ -24,7 +24,7 @@ releases:
     component: "ingress"
     namespace: "kube-system"
     vendor: "jetstack"
-    default: "true"
+    default: "false"
   chart: "stable/cert-manager"
   version: "v0.4.0"
   values:

--- a/helmfile.d/0120.cert-manager.yaml
+++ b/helmfile.d/0120.cert-manager.yaml
@@ -1,7 +1,6 @@
 helmDefaults:
   args:
     - "--wait"
-    - "--recreate-pods"
     - "--timeout=600" 
     - "--force"
     - "--reset-values"
@@ -30,10 +29,28 @@ releases:
   version: "v0.4.0"
   values:
     - rbac:
-        create: true
+        ### Optional: CERT_MANAGER_RBAC_CREATE;
+        create: '{{ env "CERT_MANAGER_RBAC_CREATE" | default "true" }}'
       ingressShim:
-        defaultIssuerName: "letsencrypt-prod"
-        defaultIssuerKind: "ClusterIssuer"
+        ### Optional: CERT_MANAGER_INGRESS_SHIM_DEFAULT_ISSUER_NAME;
+        defaultIssuerName: '{{ env "CERT_MANAGER_INGRESS_SHIM_DEFAULT_ISSUER_NAME" | default "letsencrypt-prod" }}'
+        ### Optional: CERT_MANAGER_INGRESS_SHIM_DEFAULT_ISSUER_KIND;
+        defaultIssuerKind: '{{ env "CERT_MANAGER_INGRESS_SHIM_DEFAULT_ISSUER_KIND" | default "ClusterIssuer" }}'
       tolerations:
         - key: "node-role.kubernetes.io/node"
           effect: "NoSchedule"
+      serviceAccount:
+        # Specifies whether a service account should be created
+        ### Optional: CERT_MANAGER_SERVICE_ACCOUNT_CREATE;
+        create: '{{ env "CERT_MANAGER_SERVICE_ACCOUNT_CREATE" | default "true" }}'
+        # The name of the service account to use.
+        # If not set and create is true, a name is generated using the fullname template
+        ### Optional: CERT_MANAGER_SERVICE_ACCOUNT_CREATE;
+        name: '{{ env "CERT_MANAGER_SERVICE_ACCOUNT_NAME" | default "" }}'
+      resources:
+        limits:
+          cpu: "200m"
+          memory: "256Mi"
+        requests:
+          cpu: "50m"
+          memory: "128Mi"

--- a/helmfile.d/0120.cert-manager.yaml
+++ b/helmfile.d/0120.cert-manager.yaml
@@ -1,0 +1,39 @@
+helmDefaults:
+  args:
+    - "--wait"
+    - "--recreate-pods"
+    - "--timeout=600" 
+    - "--force"
+    - "--reset-values"
+
+repositories:
+# Stable repo of official helm charts
+- name: "stable"
+  url: "https://kubernetes-charts.storage.googleapis.com"
+
+
+releases:
+
+################################################################################
+## CERT-MANAGER - Automatic Let's Encrypt for Ingress  #########################
+################################################################################
+
+- name: "cert-manager"
+  namespace: "kube-system"
+  labels:
+    chart: "cert-manager"
+    component: "ingress"
+    namespace: "kube-system"
+    vendor: "jetstack"
+    default: "true"
+  chart: "stable/cert-manager"
+  version: "v0.4.0"
+  values:
+    - rbac:
+        create: true
+      ingressShim:
+        defaultIssuerName: "letsencrypt-prod"
+        defaultIssuerKind: "ClusterIssuer"
+      tolerations:
+        - key: "node-role.kubernetes.io/node"
+          effect: "NoSchedule"


### PR DESCRIPTION
## what
* Added helmfile for Cert Manager chart

## why
* `kube-lego` deprecated

## credits
* Donated by @rohitverma of Niki.ai

## references
#1 