### PR TITLE
Upgrade build-harness

### DIFF
--- a/codefresh.yml
+++ b/codefresh.yml
@@ -6,7 +6,7 @@ steps:
     title: Init variables
     image: alpine
     commands:
-      - cf_export BUILD_HARNESS_VERSION=0.5.5
+      - cf_export BUILD_HARNESS_VERSION=0.7.0
       - cf_export GIT_BRANCH=${{CF_BRANCH}}
 
   build_image:


### PR DESCRIPTION
## what
* Upgrade to `build-harness:0.7.0`

## why
* Support CI/CD of branch names with slashes