### PR TITLE
[grafana] add nginx ingress dashboard

### DIFF
--- a/helmfile.d/0420.grafana.yaml
+++ b/helmfile.d/0420.grafana.yaml
@@ -58,7 +58,11 @@ releases:
             options:
               path: /var/lib/grafana/dashboards/default
       dashboards:
-        default: {}
+        default:
+          nginx-ingress-stats:
+            gnetId: 7173
+            revision: 1
+            datasource: Prometheus
       resources:
         limits:
           cpu: "50m"

--- a/helmfile.d/values/grafana.dashboards.yaml
+++ b/helmfile.d/values/grafana.dashboards.yaml
@@ -6,8 +6,6 @@
 #       datasource: Prometheus
 #     some-dashboard:
 #       json: |-
-#         {
-
-#         }
+#         {...}
 #     local-dashboard:
 #       url: https://example.com/repository/test.json


### PR DESCRIPTION
## what
add nginx ingress dashboard by default

## why
#8 
