### PR TITLE
[kibana] Fix env parameter quoting and structure

### DIFF
--- a/helmfile.d/0630.kibana.yaml
+++ b/helmfile.d/0630.kibana.yaml
@@ -71,18 +71,21 @@ releases:
     files:
       kibana.yml:
         ## Default Kibana configuration from kibana-docker.
-        server.name: kibana
-        server.host: "localhost"
-        elasticsearch.url: {{ env "ELASTICSEARCH_HOST" }}:{{ env "ELASTICSEARCH_PORT" }}
+        server:
+          name: "kibana"
+          host: '{{ env "KIBANA_SERVER_HOST" | default "localhost" }}'
+          port: {{ env "KIBANA_SERVER_PORT" | default "5601" }}
+          defaultRoute: "/app/kibana"
+        elasticsearch:
+          url: '{{ env "ELASTICSEARCH_HOST" | default "elasticsearch" }}:{{ env "ELASTICSEARCH_PORT" | default "80" }}'
 
         ## Custom config properties
         ## Ref: https://www.elastic.co/guide/en/kibana/current/settings.html
-        server.port: {{ env "KIBANA_SERVER_PORT" | default "5601" }}
-        logging.verbose: "false"
-        server.defaultRoute: "/app/kibana"
+        logging:
+          verbose: "false"
     env:
-    # All Kibana configuration options are adjustable via env vars.
-    # To adjust a config option to an env var uppercase + replace `.` with `_`
-    # Ref: https://www.elastic.co/guide/en/kibana/current/settings.html
-    ELASTICSEARCH_URL: {{ env "ELASTICSEARCH_HOST" }}:{{ env "ELASTICSEARCH_PORT" }}
-    SERVER_PORT: {{ env "KIBANA_SERVER_PORT" | default "5601" }}
+      # All Kibana configuration options are adjustable via env vars.
+      # To adjust a config option to an env var uppercase + replace `.` with `_`
+      # Ref: https://www.elastic.co/guide/en/kibana/current/settings.html
+      ELASTICSEARCH_URL: '{{ env "ELASTICSEARCH_HOST" | default "elasticsearch" }}:{{ env "ELASTICSEARCH_PORT" | default "80" }}'
+      SERVER_PORT: '{{ env "KIBANA_SERVER_PORT" | default "5601" }}'


### PR DESCRIPTION
## what
* Expand YAML shorthand notation to nested blocks
* Fix indention of env vars
* Provide defaults

## why
* Avoid using yaml dot-notation shorthand as it easily leads to poorly formed YAML
* Always quote ENVs to avoid accidentally introducing bad YAML
* The `:` is not a valid yaml string character unless quoted
* Helmfiles are first preprocessed as text, then as yaml. The gotemplating needs to render valid YAML.

## references
- <https://github.com/cloudposse/helmfiles/issues/11>