### PR TITLE
[portal] Add conditions to portal backends

### DIFF
--- a/helmfile.d/0000.kube2iam.yaml
+++ b/helmfile.d/0000.kube2iam.yaml
@@ -1,7 +1,6 @@
 helmDefaults:
   args:
     - "--wait"
-    - "--recreate-pods"
     - "--timeout=600"
     - "--force"
     - "--reset-values"

--- a/helmfile.d/0010.kiam.yaml
+++ b/helmfile.d/0010.kiam.yaml
@@ -1,8 +1,7 @@
 helmDefaults:
   args:
     - "--wait"
-    - "--recreate-pods"
-    - "--timeout=600" 
+    - "--timeout=600"
     - "--force"
     - "--reset-values"
 

--- a/helmfile.d/0100.external-dns.yaml
+++ b/helmfile.d/0100.external-dns.yaml
@@ -1,8 +1,7 @@
 helmDefaults:
   args:
     - "--wait"
-    - "--recreate-pods"
-    - "--timeout=600" 
+    - "--timeout=600"
     - "--force"
     - "--reset-values"
 

--- a/helmfile.d/0110.kube-lego.yaml
+++ b/helmfile.d/0110.kube-lego.yaml
@@ -1,8 +1,7 @@
 helmDefaults:
   args:
     - "--wait"
-    - "--recreate-pods"
-    - "--timeout=600" 
+    - "--timeout=600"
     - "--force"
     - "--reset-values"
 

--- a/helmfile.d/0300.chartmuseum.yaml
+++ b/helmfile.d/0300.chartmuseum.yaml
@@ -1,8 +1,7 @@
 helmDefaults:
   args:
     - "--wait"
-    - "--recreate-pods"
-    - "--timeout=600" 
+    - "--timeout=600"
     - "--force"
     - "--reset-values"
 

--- a/helmfile.d/0310.chartmuseum-api.yaml
+++ b/helmfile.d/0310.chartmuseum-api.yaml
@@ -1,8 +1,7 @@
 helmDefaults:
   args:
     - "--wait"
-    - "--recreate-pods"
-    - "--timeout=600" 
+    - "--timeout=600"
     - "--force"
     - "--reset-values"
 

--- a/helmfile.d/0320.nginx-ingress.yaml
+++ b/helmfile.d/0320.nginx-ingress.yaml
@@ -1,8 +1,7 @@
 helmDefaults:
   args:
     - "--wait"
-    - "--recreate-pods"
-    - "--timeout=600" 
+    - "--timeout=600"
     - "--force"
     - "--reset-values"
 

--- a/helmfile.d/0400.prometheus-operator.yaml
+++ b/helmfile.d/0400.prometheus-operator.yaml
@@ -1,8 +1,7 @@
 helmDefaults:
   args:
     - "--wait"
-    - "--recreate-pods"
-    - "--timeout=600" 
+    - "--timeout=600"
     - "--force"
     - "--reset-values"
 

--- a/helmfile.d/0500.datalog.yaml
+++ b/helmfile.d/0500.datalog.yaml
@@ -1,8 +1,7 @@
 helmDefaults:
   args:
     - "--wait"
-    - "--recreate-pods"
-    - "--timeout=600" 
+    - "--timeout=600"
     - "--force"
     - "--reset-values"
 

--- a/helmfile.d/0510.fluentd-datadog-logs.yaml
+++ b/helmfile.d/0510.fluentd-datadog-logs.yaml
@@ -1,7 +1,6 @@
 helmDefaults:
   args:
   - "--wait"
-  - "--recreate-pods"
   - "--timeout=600"
   - "--force"
   - "--reset-values"

--- a/helmfile.d/0520.fluentd-elasticsearch-logs.yaml
+++ b/helmfile.d/0520.fluentd-elasticsearch-logs.yaml
@@ -1,7 +1,6 @@
 helmDefaults:
   args:
   - "--wait"
-  - "--recreate-pods"
   - "--timeout=600"
   - "--force"
   - "--reset-values"

--- a/helmfile.d/0600.heapster.yaml
+++ b/helmfile.d/0600.heapster.yaml
@@ -1,8 +1,7 @@
 helmDefaults:
   args:
     - "--wait"
-    - "--recreate-pods"
-    - "--timeout=600" 
+    - "--timeout=600"
     - "--force"
     - "--reset-values"
 

--- a/helmfile.d/0610.dashboard.yaml
+++ b/helmfile.d/0610.dashboard.yaml
@@ -1,8 +1,7 @@
 helmDefaults:
   args:
     - "--wait"
-    - "--recreate-pods"
-    - "--timeout=600" 
+    - "--timeout=600"
     - "--force"
     - "--reset-values"
 

--- a/helmfile.d/0620.portal.yaml
+++ b/helmfile.d/0620.portal.yaml
@@ -1,9 +1,9 @@
 helmDefaults:
   args:
-    - "--wait"
-    - "--timeout=600"
-    - "--force"
-    - "--reset-values"
+  - "--wait"
+  - "--timeout=600"
+  - "--force"
+  - "--reset-values"
 
 repositories:
 # Cloud Posse incubator repo of helm charts
@@ -33,163 +33,163 @@ releases:
   chart: "cloudposse-incubator/portal"
   version: "0.1.0"
   values:
-    - backends:
-        ### Optional: PORTAL_BACKEND_K8S_DASHBOARD_ENABLED
-        {{ if eq (env "PORTAL_BACKEND_K8S_DASHBOARD_ENABLED" | default "true") "true" }}
-        dashboard:
-          ### Optional: PORTAL_BACKEND_K8S_DASHBOARD_NAME
-          name: '{{ env "PORTAL_BACKEND_K8S_DASHBOARD_NAME" | default "Kubernetes" }}'
-          ### Optional: PORTAL_BACKEND_K8S_DASHBOARD_ENDPOINT;
-          endpoint: '{{ env "PORTAL_BACKEND_K8S_DASHBOARD_ENDPOINT" | default "https://kubernetes-dashboard.kube-system:443" }}'
-          external: false
-        {{ end }}
-        ### Optional: PORTAL_BACKEND_GRAFANA_ENABLED
-        {{ if eq (env "PORTAL_BACKEND_GRAFANA_ENABLED" | default "true") "true" }}
-        grafana:
-          ### Optional: PORTAL_BACKEND_GRAFANA_NAME
-          name: '{{ env "PORTAL_BACKEND_GRAFANA_NAME" | default "Grafana" }}'
-          ### Optional: PORTAL_BACKEND_GRAFANA_ENDPOINT
-          endpoint: '{{ env "PORTAL_BACKEND_GRAFANA_ENDPOINT" | default "http://kube-prometheus-grafana.monitoring:80" }}'
-          external: false
-        {{ end }}
-        ### Optional: PORTAL_BACKEND_ALERTS_ENABLED
-        {{ if eq (env "PORTAL_BACKEND_ALERTS_ENABLED" | default "true") "true" }}
-        alerts:
-          ### Optional: PORTAL_BACKEND_ALERTS_NAME
-          name: '{{ env "PORTAL_BACKEND_ALERTS_NAME" | default "Alerts" }}'
-          ### Optional: PORTAL_BACKEND_ALERTS_ENDPOINT
-          endpoint: '{{ env "PORTAL_BACKEND_ALERTS_ENDPOINT" | default "http://kube-prometheus-alertmanager.monitoring:9093" }}'
-          external: false
-        {{ end }}
-        ### Optional: PORTAL_BACKEND_PROMETHEUS_ENABLED
-        {{ if eq (env "PORTAL_BACKEND_PROMETHEUS_ENABLED" | default "true") "true" }}
-        prometheus:
-          ### Optional: PORTAL_BACKEND_PROMETHEUS_NAME
-          name: '{{ env "PORTAL_BACKEND_PROMETHEUS_NAME" | default "Prometheus" }}'
-          ### Optional: PORTAL_BACKEND_PROMETHEUS_ENDPOINT
-          endpoint: '{{ env "PORTAL_BACKEND_PROMETHEUS_ENDPOINT" | default "http://kube-prometheus-prometheus.monitoring:9090" }}'
-          external: false
-        {{ end }}
-        ### Optional: PORTAL_BACKEND_DOCS_ENABLED
-        {{ if eq (env "PORTAL_BACKEND_DOCS_ENABLED" | default "true") "true" }}
-        docs:
-          ### Optional: PORTAL_BACKEND_DOCS_NAME
-          name: '{{ env "PORTAL_BACKEND_DOCS_NAME" | default "Docs" }}'
-          ### Optional: PORTAL_BACKEND_DOCS_ENDPOINT
-          endpoint: '{{ env "PORTAL_BACKEND_DOCS_ENDPOINT" | default "https://docs.cloudposse.com/" }}'
-          external: true
-        {{ end }}
-        ### Optional: PORTAL_BACKEND_KIBANA_ENABLED
-        {{ if eq (env "PORTAL_BACKEND_KIBANA_ENABLED" | default "false") "true" }}
-        kibana:
-          ### Optional: PORTAL_BACKEND_KIBANA_NAME
-          name: '{{ env "PORTAL_BACKEND_KIBANA_NAME" | default "Kibana" }}'
-          ### Optional: PORTAL_BACKEND_KIBANA_ENDPOINT
-          endpoint: '{{ env "PORTAL_BACKEND_KIBANA_ENDPOINT" | default "http://kibana.monitoring:80" }}'
-          external: false
-        {{ end }}
-    config:
-        ### Required: PORTAL_TITLE
-        title: '{{ env "PORTAL_TITLE" }}'
-        ### Required: PORTAL_BRAND
-        brand: '{{ env "PORTAL_BRAND" }}'
-        ### Required: PORTAL_HOSTNAME
-        basehost: '{{ env "PORTAL_HOSTNAME" }}'
-        image:
-          ### Optional: PORTAL_BRAND_IMAGE_FAVICON_URL
-          favicon: '{{ env "PORTAL_BRAND_IMAGE_FAVICON_URL" | default "https://cloudposse.com/wp-content/uploads/sites/29/2016/04/favicon-152.png" }}'
-          ### Optional: PORTAL_BRAND_IMAGE_URL
-          url: '{{ env "PORTAL_BRAND_IMAGE_URL" | default "https://raw.githubusercontent.com/cloudposse/helm-chart-scaffolding/master/logo.png" }}'
-          ### Optional: PORTAL_BRAND_IMAGE_WIDTH
-          width: '{{ env "PORTAL_BRAND_IMAGE_WIDTH" | default "35" }}'
+  - backends:
+      ### Optional: PORTAL_BACKEND_K8S_DASHBOARD_ENABLED
+      {{ if eq (env "PORTAL_BACKEND_K8S_DASHBOARD_ENABLED" | default "true") "true" }}
       dashboard:
-        ### Optional: PORTAL_DASHBOARD_REPLICA_COUNT
-        replicaCount: '{{ env "PORTAL_DASHBOARD_REPLICA_COUNT" | default "2" }}'
+        ### Optional: PORTAL_BACKEND_K8S_DASHBOARD_NAME
+        name: '{{ env "PORTAL_BACKEND_K8S_DASHBOARD_NAME" | default "Kubernetes" }}'
+        ### Optional: PORTAL_BACKEND_K8S_DASHBOARD_ENDPOINT;
+        endpoint: '{{ env "PORTAL_BACKEND_K8S_DASHBOARD_ENDPOINT" | default "https://kubernetes-dashboard.kube-system:443" }}'
+        external: false
+      {{ end }}
+      ### Optional: PORTAL_BACKEND_GRAFANA_ENABLED
+      {{ if eq (env "PORTAL_BACKEND_GRAFANA_ENABLED" | default "true") "true" }}
+      grafana:
+        ### Optional: PORTAL_BACKEND_GRAFANA_NAME
+        name: '{{ env "PORTAL_BACKEND_GRAFANA_NAME" | default "Grafana" }}'
+        ### Optional: PORTAL_BACKEND_GRAFANA_ENDPOINT
+        endpoint: '{{ env "PORTAL_BACKEND_GRAFANA_ENDPOINT" | default "http://kube-prometheus-grafana.monitoring:80" }}'
+        external: false
+      {{ end }}
+      ### Optional: PORTAL_BACKEND_ALERTS_ENABLED
+      {{ if eq (env "PORTAL_BACKEND_ALERTS_ENABLED" | default "true") "true" }}
+      alerts:
+        ### Optional: PORTAL_BACKEND_ALERTS_NAME
+        name: '{{ env "PORTAL_BACKEND_ALERTS_NAME" | default "Alerts" }}'
+        ### Optional: PORTAL_BACKEND_ALERTS_ENDPOINT
+        endpoint: '{{ env "PORTAL_BACKEND_ALERTS_ENDPOINT" | default "http://kube-prometheus-alertmanager.monitoring:9093" }}'
+        external: false
+      {{ end }}
+      ### Optional: PORTAL_BACKEND_PROMETHEUS_ENABLED
+      {{ if eq (env "PORTAL_BACKEND_PROMETHEUS_ENABLED" | default "true") "true" }}
+      prometheus:
+        ### Optional: PORTAL_BACKEND_PROMETHEUS_NAME
+        name: '{{ env "PORTAL_BACKEND_PROMETHEUS_NAME" | default "Prometheus" }}'
+        ### Optional: PORTAL_BACKEND_PROMETHEUS_ENDPOINT
+        endpoint: '{{ env "PORTAL_BACKEND_PROMETHEUS_ENDPOINT" | default "http://kube-prometheus-prometheus.monitoring:9090" }}'
+        external: false
+      {{ end }}
+      ### Optional: PORTAL_BACKEND_DOCS_ENABLED
+      {{ if eq (env "PORTAL_BACKEND_DOCS_ENABLED" | default "true") "true" }}
+      docs:
+        ### Optional: PORTAL_BACKEND_DOCS_NAME
+        name: '{{ env "PORTAL_BACKEND_DOCS_NAME" | default "Docs" }}'
+        ### Optional: PORTAL_BACKEND_DOCS_ENDPOINT
+        endpoint: '{{ env "PORTAL_BACKEND_DOCS_ENDPOINT" | default "https://docs.cloudposse.com/" }}'
+        external: true
+      {{ end }}
+      ### Optional: PORTAL_BACKEND_KIBANA_ENABLED
+      {{ if eq (env "PORTAL_BACKEND_KIBANA_ENABLED" | default "false") "true" }}
+      kibana:
+        ### Optional: PORTAL_BACKEND_KIBANA_NAME
+        name: '{{ env "PORTAL_BACKEND_KIBANA_NAME" | default "Kibana" }}'
+        ### Optional: PORTAL_BACKEND_KIBANA_ENDPOINT
+        endpoint: '{{ env "PORTAL_BACKEND_KIBANA_ENDPOINT" | default "http://kibana.monitoring:80" }}'
+        external: false
+      {{ end }}
+  - config:
+      ### Required: PORTAL_TITLE
+      title: '{{ env "PORTAL_TITLE" }}'
+      ### Required: PORTAL_BRAND
+      brand: '{{ env "PORTAL_BRAND" }}'
+      ### Required: PORTAL_HOSTNAME
+      basehost: '{{ env "PORTAL_HOSTNAME" }}'
+      image:
+        ### Optional: PORTAL_BRAND_IMAGE_FAVICON_URL
+        favicon: '{{ env "PORTAL_BRAND_IMAGE_FAVICON_URL" | default "https://cloudposse.com/wp-content/uploads/sites/29/2016/04/favicon-152.png" }}'
+        ### Optional: PORTAL_BRAND_IMAGE_URL
+        url: '{{ env "PORTAL_BRAND_IMAGE_URL" | default "https://raw.githubusercontent.com/cloudposse/helm-chart-scaffolding/master/logo.png" }}'
+        ### Optional: PORTAL_BRAND_IMAGE_WIDTH
+        width: '{{ env "PORTAL_BRAND_IMAGE_WIDTH" | default "35" }}'
+    dashboard:
+      ### Optional: PORTAL_DASHBOARD_REPLICA_COUNT
+      replicaCount: '{{ env "PORTAL_DASHBOARD_REPLICA_COUNT" | default "2" }}'
+      image:
+        repository: "nginx"
+        ### Optional: PORTAL_DASHBOARD_IMAGE_TAG
+        tag: '{{ env "PORTAL_DASHBOARD_IMAGE_TAG" | default "latest" }}'
+        pullPolicy: "Always"
+      service:
+        externalPort: "80"
+        internalPort: "80"
+      resources:
+        limits:
+          cpu: "5m"
+          memory: "16Mi"
+        requests:
+          cpu: "3m"
+          memory: "8Mi"
+    proxy:
+      enabled: true
+      ### Optional: PORTAL_PROXY_REPLICA_COUNT
+      replicaCount: '{{ env "PORTAL_PROXY_REPLICA_COUNT" | default "2" }}'
+      image:
+        repository: "traefik"
+        ### Optional: PORTAL_PROXY_IMAGE_TAG
+        tag: '{{ env "PORTAL_PROXY_IMAGE_TAG" | default "1.5.4" }}'
+        pullPolicy: "Always"
+      service:
+        externalPort: "80"
+        internalPort: "80"
+      resources:
+        limits:
+          cpu: "5m"
+          memory: "64Mi"
+        requests:
+          cpu: "3m"
+          memory: "32Mi"
+    oauth2-proxy:
+      app:
+        useSSL: false
+        upstreams:
+        - "file:///dev/null"
+        provider: "github"
+        ### Required: PORTAL_OAUTH2_PROXY_GITHUB_CLIENT_ID
+        clientID: '{{ env "PORTAL_OAUTH2_PROXY_GITHUB_CLIENT_ID" }}'
+        ### Required: PORTAL_OAUTH2_PROXY_GITHUB_CLIENT_SECRET
+        clientSecret: '{{ env "PORTAL_OAUTH2_PROXY_GITHUB_CLIENT_SECRET" }}'
+        ### Required: PORTAL_OAUTH2_PROXY_GITHUB_ORGANIZATION
+        githubOrg: '{{ env "PORTAL_OAUTH2_PROXY_GITHUB_ORGANIZATION" }}'
+        ### Required: PORTAL_OAUTH2_PROXY_GITHUB_TEAM
+        githubTeam: '{{ env "PORTAL_OAUTH2_PROXY_GITHUB_TEAM" }}'
+        requestLogging: false
+        passAccessToken: false
+        passBasicAuth: false
+        passHostHeader: true
+        ### Required: PORTAL_OAUTH2_PROXY_COOKIE_NAME
+        cookieName: '{{ env "PORTAL_OAUTH2_PROXY_COOKIE_NAME" }}'
+        ### Required: PORTAL_OAUTH2_PROXY_COOKIE_SECRET
+        cookieSecret: '{{ env "PORTAL_OAUTH2_PROXY_COOKIE_SECRET" }}'
+        ### Required: PORTAL_HOSTNAME
+        cookieDomain: '{{ env "PORTAL_HOSTNAME" }}'
+        cookieSecure: true
+        cookieHttponly: false
+        ### Optional: PORTAL_OAUTH2_PROXY_REPLICA_COUNT
+        replicaCount: '{{ env "PORTAL_OAUTH2_PROXY_REPLICA_COUNT" | default "2" }}'
         image:
-          repository: "nginx"
-          ### Optional: PORTAL_DASHBOARD_IMAGE_TAG
-          tag: '{{ env "PORTAL_DASHBOARD_IMAGE_TAG" | default "latest" }}'
+          repository: "cloudposse/oauth2-proxy"
+          ### Optional: PORTAL_OAUTH2_PROXY_IMAGE_TAG
+          tag: '{{ env "PORTAL_OAUTH2_PROXY_IMAGE_TAG" | default "2.2" }}'
           pullPolicy: "Always"
-        service:
-          externalPort: "80"
-          internalPort: "80"
         resources:
           limits:
-            cpu: "5m"
+            cpu: "10m"
             memory: "16Mi"
           requests:
-            cpu: "3m"
-            memory: "8Mi"
-      proxy:
-        enabled: true
-        ### Optional: PORTAL_PROXY_REPLICA_COUNT
-        replicaCount: '{{ env "PORTAL_PROXY_REPLICA_COUNT" | default "2" }}'
-        image:
-          repository: "traefik"
-          ### Optional: PORTAL_PROXY_IMAGE_TAG
-          tag: '{{ env "PORTAL_PROXY_IMAGE_TAG" | default "1.5.4" }}'
-          pullPolicy: "Always"
-        service:
-          externalPort: "80"
-          internalPort: "80"
-        resources:
-          limits:
             cpu: "5m"
-            memory: "64Mi"
-          requests:
-            cpu: "3m"
-            memory: "32Mi"
-      oauth2-proxy:
-        app:
-          useSSL: false
-          upstreams:
-            - "file:///dev/null"
-          provider: "github"
-          ### Required: PORTAL_OAUTH2_PROXY_GITHUB_CLIENT_ID
-          clientID: '{{ env "PORTAL_OAUTH2_PROXY_GITHUB_CLIENT_ID" }}'
-          ### Required: PORTAL_OAUTH2_PROXY_GITHUB_CLIENT_SECRET
-          clientSecret: '{{ env "PORTAL_OAUTH2_PROXY_GITHUB_CLIENT_SECRET" }}'
-          ### Required: PORTAL_OAUTH2_PROXY_GITHUB_ORGANIZATION
-          githubOrg: '{{ env "PORTAL_OAUTH2_PROXY_GITHUB_ORGANIZATION" }}'
-          ### Required: PORTAL_OAUTH2_PROXY_GITHUB_TEAM
-          githubTeam: '{{ env "PORTAL_OAUTH2_PROXY_GITHUB_TEAM" }}'
-          requestLogging: false
-          passAccessToken: false
-          passBasicAuth: false
-          passHostHeader: true
-          ### Required: PORTAL_OAUTH2_PROXY_COOKIE_NAME
-          cookieName: '{{ env "PORTAL_OAUTH2_PROXY_COOKIE_NAME" }}'
-          ### Required: PORTAL_OAUTH2_PROXY_COOKIE_SECRET
-          cookieSecret: '{{ env "PORTAL_OAUTH2_PROXY_COOKIE_SECRET" }}'
-          ### Required: PORTAL_HOSTNAME
-          cookieDomain: '{{ env "PORTAL_HOSTNAME" }}'
-          cookieSecure: true
-          cookieHttponly: false
-          ### Optional: PORTAL_OAUTH2_PROXY_REPLICA_COUNT
-          replicaCount: '{{ env "PORTAL_OAUTH2_PROXY_REPLICA_COUNT" | default "2" }}'
-          image:
-            repository: "cloudposse/oauth2-proxy"
-            ### Optional: PORTAL_OAUTH2_PROXY_IMAGE_TAG
-            tag: '{{ env "PORTAL_OAUTH2_PROXY_IMAGE_TAG" | default "2.2" }}'
-            pullPolicy: "Always"
-          resources:
-            limits:
-              cpu: "10m"
-              memory: "16Mi"
-            requests:
-              cpu: "5m"
-              memory: "8Mi"
-      ingress:
-        enabled: true
-        dns:
-          enabled: false
-        tls:
-          ### Optional: PORTAL_INGRESS_TLS_ENABLED; e.g. false
-          enabled: '{{ env "PORTAL_INGRESS_TLS_ENABLED" | default "true" }}'
-        annotations:
-          kubernetes.io/ingress.class: "nginx"
-          kubernetes.io/tls-acme: "true"
-          ### Required: PORTAL_INGRESS; e.g. ingress.us-west-2.staging.cloudposse.org
-          external-dns.alpha.kubernetes.io/target: '{{ env "PORTAL_INGRESS" }}'
-          # DNS TTL for PORTAL_HOSTNAME; e.g. 60
-          external-dns.alpha.kubernetes.io/ttl: "60"
+            memory: "8Mi"
+    ingress:
+      enabled: true
+      dns:
+        enabled: false
+      tls:
+        ### Optional: PORTAL_INGRESS_TLS_ENABLED; e.g. false
+        enabled: '{{ env "PORTAL_INGRESS_TLS_ENABLED" | default "true" }}'
+      annotations:
+        kubernetes.io/ingress.class: "nginx"
+        kubernetes.io/tls-acme: "true"
+        ### Required: PORTAL_INGRESS; e.g. ingress.us-west-2.staging.cloudposse.org
+        external-dns.alpha.kubernetes.io/target: '{{ env "PORTAL_INGRESS" }}'
+        # DNS TTL for PORTAL_HOSTNAME; e.g. 60
+        external-dns.alpha.kubernetes.io/ttl: "60"

--- a/helmfile.d/0620.portal.yaml
+++ b/helmfile.d/0620.portal.yaml
@@ -1,7 +1,6 @@
 helmDefaults:
   args:
     - "--wait"
-    - "--recreate-pods"
     - "--timeout=600"
     - "--force"
     - "--reset-values"
@@ -35,56 +34,80 @@ releases:
   version: "0.1.0"
   values:
     - backends:
+        ### Optional: PORTAL_BACKEND_K8S_DASHBOARD_ENABLED
+        {{ if eq (env "PORTAL_BACKEND_K8S_DASHBOARD_ENABLED" | default "true") "true" }}
         dashboard:
-          ### Optional: PORTAL_BACKEND_K8S_DASHBOARD_NAME;
+          ### Optional: PORTAL_BACKEND_K8S_DASHBOARD_NAME
           name: '{{ env "PORTAL_BACKEND_K8S_DASHBOARD_NAME" | default "Kubernetes" }}'
           ### Optional: PORTAL_BACKEND_K8S_DASHBOARD_ENDPOINT;
           endpoint: '{{ env "PORTAL_BACKEND_K8S_DASHBOARD_ENDPOINT" | default "https://kubernetes-dashboard.kube-system:443" }}'
           external: false
+        {{ end }}
+        ### Optional: PORTAL_BACKEND_GRAFANA_ENABLED
+        {{ if eq (env "PORTAL_BACKEND_GRAFANA_ENABLED" | default "true") "true" }}
         grafana:
-          ### Optional: PORTAL_BACKEND_GRAFANA_NAME;
+          ### Optional: PORTAL_BACKEND_GRAFANA_NAME
           name: '{{ env "PORTAL_BACKEND_GRAFANA_NAME" | default "Grafana" }}'
-          ### Optional: PORTAL_BACKEND_GRAFANA_ENDPOINT;
+          ### Optional: PORTAL_BACKEND_GRAFANA_ENDPOINT
           endpoint: '{{ env "PORTAL_BACKEND_GRAFANA_ENDPOINT" | default "http://kube-prometheus-grafana.monitoring:80" }}'
           external: false
+        {{ end }}
+        ### Optional: PORTAL_BACKEND_ALERTS_ENABLED
+        {{ if eq (env "PORTAL_BACKEND_ALERTS_ENABLED" | default "true") "true" }}
         alerts:
-          ### Optional: PORTAL_BACKEND_ALERTS_NAME;
+          ### Optional: PORTAL_BACKEND_ALERTS_NAME
           name: '{{ env "PORTAL_BACKEND_ALERTS_NAME" | default "Alerts" }}'
-          ### Optional: PORTAL_BACKEND_ALERTS_ENDPOINT;
+          ### Optional: PORTAL_BACKEND_ALERTS_ENDPOINT
           endpoint: '{{ env "PORTAL_BACKEND_ALERTS_ENDPOINT" | default "http://kube-prometheus-alertmanager.monitoring:9093" }}'
           external: false
+        {{ end }}
+        ### Optional: PORTAL_BACKEND_PROMETHEUS_ENABLED
+        {{ if eq (env "PORTAL_BACKEND_PROMETHEUS_ENABLED" | default "true") "true" }}
         prometheus:
-          ### Optional: PORTAL_BACKEND_PROMETHEUS_NAME;
+          ### Optional: PORTAL_BACKEND_PROMETHEUS_NAME
           name: '{{ env "PORTAL_BACKEND_PROMETHEUS_NAME" | default "Prometheus" }}'
-          ### Optional: PORTAL_BACKEND_PROMETHEUS_ENDPOINT;
+          ### Optional: PORTAL_BACKEND_PROMETHEUS_ENDPOINT
           endpoint: '{{ env "PORTAL_BACKEND_PROMETHEUS_ENDPOINT" | default "http://kube-prometheus-prometheus.monitoring:9090" }}'
           external: false
+        {{ end }}
+        ### Optional: PORTAL_BACKEND_DOCS_ENABLED
+        {{ if eq (env "PORTAL_BACKEND_DOCS_ENABLED" | default "true") "true" }}
         docs:
-          ### Optional: PORTAL_BACKEND_DOCS_NAME;
+          ### Optional: PORTAL_BACKEND_DOCS_NAME
           name: '{{ env "PORTAL_BACKEND_DOCS_NAME" | default "Docs" }}'
-          ### Optional: PORTAL_BACKEND_DOCS_ENDPOINT;
+          ### Optional: PORTAL_BACKEND_DOCS_ENDPOINT
           endpoint: '{{ env "PORTAL_BACKEND_DOCS_ENDPOINT" | default "https://docs.cloudposse.com/" }}'
           external: true
-      config:
-        ### Required: PORTAL_TITLE;
+        {{ end }}
+        ### Optional: PORTAL_BACKEND_KIBANA_ENABLED
+        {{ if eq (env "PORTAL_BACKEND_KIBANA_ENABLED" | default "false") "true" }}
+        kibana:
+          ### Optional: PORTAL_BACKEND_KIBANA_NAME
+          name: '{{ env "PORTAL_BACKEND_KIBANA_NAME" | default "Kibana" }}'
+          ### Optional: PORTAL_BACKEND_KIBANA_ENDPOINT
+          endpoint: '{{ env "PORTAL_BACKEND_KIBANA_ENDPOINT" | default "http://kibana.monitoring:80" }}'
+          external: false
+        {{ end }}
+    config:
+        ### Required: PORTAL_TITLE
         title: '{{ env "PORTAL_TITLE" }}'
-        ### Required: PORTAL_BRAND;
+        ### Required: PORTAL_BRAND
         brand: '{{ env "PORTAL_BRAND" }}'
-        ### Required: PORTAL_HOSTNAME;
+        ### Required: PORTAL_HOSTNAME
         basehost: '{{ env "PORTAL_HOSTNAME" }}'
         image:
-          ### Optional: PORTAL_BRAND_IMAGE_FAVICON_URL;
+          ### Optional: PORTAL_BRAND_IMAGE_FAVICON_URL
           favicon: '{{ env "PORTAL_BRAND_IMAGE_FAVICON_URL" | default "https://cloudposse.com/wp-content/uploads/sites/29/2016/04/favicon-152.png" }}'
-          ### Optional: PORTAL_BRAND_IMAGE_URL;
+          ### Optional: PORTAL_BRAND_IMAGE_URL
           url: '{{ env "PORTAL_BRAND_IMAGE_URL" | default "https://raw.githubusercontent.com/cloudposse/helm-chart-scaffolding/master/logo.png" }}'
-          ### Optional: PORTAL_BRAND_IMAGE_WIDTH;
+          ### Optional: PORTAL_BRAND_IMAGE_WIDTH
           width: '{{ env "PORTAL_BRAND_IMAGE_WIDTH" | default "35" }}'
       dashboard:
-        ### Optional: PORTAL_DASHBOARD_REPLICA_COUNT;
+        ### Optional: PORTAL_DASHBOARD_REPLICA_COUNT
         replicaCount: '{{ env "PORTAL_DASHBOARD_REPLICA_COUNT" | default "2" }}'
         image:
           repository: "nginx"
-          ### Optional: PORTAL_DASHBOARD_IMAGE_TAG;
+          ### Optional: PORTAL_DASHBOARD_IMAGE_TAG
           tag: '{{ env "PORTAL_DASHBOARD_IMAGE_TAG" | default "latest" }}'
           pullPolicy: "Always"
         service:
@@ -99,11 +122,11 @@ releases:
             memory: "8Mi"
       proxy:
         enabled: true
-        ### Optional: PORTAL_PROXY_REPLICA_COUNT;
+        ### Optional: PORTAL_PROXY_REPLICA_COUNT
         replicaCount: '{{ env "PORTAL_PROXY_REPLICA_COUNT" | default "2" }}'
         image:
           repository: "traefik"
-          ### Optional: PORTAL_PROXY_IMAGE_TAG;
+          ### Optional: PORTAL_PROXY_IMAGE_TAG
           tag: '{{ env "PORTAL_PROXY_IMAGE_TAG" | default "1.5.4" }}'
           pullPolicy: "Always"
         service:
@@ -122,31 +145,31 @@ releases:
           upstreams:
             - "file:///dev/null"
           provider: "github"
-          ### Required: PORTAL_OAUTH2_PROXY_GITHUB_CLIENT_ID;
+          ### Required: PORTAL_OAUTH2_PROXY_GITHUB_CLIENT_ID
           clientID: '{{ env "PORTAL_OAUTH2_PROXY_GITHUB_CLIENT_ID" }}'
-          ### Required: PORTAL_OAUTH2_PROXY_GITHUB_CLIENT_SECRET;
+          ### Required: PORTAL_OAUTH2_PROXY_GITHUB_CLIENT_SECRET
           clientSecret: '{{ env "PORTAL_OAUTH2_PROXY_GITHUB_CLIENT_SECRET" }}'
-          ### Required: PORTAL_OAUTH2_PROXY_GITHUB_ORGANIZATION;
+          ### Required: PORTAL_OAUTH2_PROXY_GITHUB_ORGANIZATION
           githubOrg: '{{ env "PORTAL_OAUTH2_PROXY_GITHUB_ORGANIZATION" }}'
-          ### Required: PORTAL_OAUTH2_PROXY_GITHUB_TEAM;
+          ### Required: PORTAL_OAUTH2_PROXY_GITHUB_TEAM
           githubTeam: '{{ env "PORTAL_OAUTH2_PROXY_GITHUB_TEAM" }}'
           requestLogging: false
           passAccessToken: false
           passBasicAuth: false
           passHostHeader: true
-          ### Required: PORTAL_OAUTH2_PROXY_COOKIE_NAME;
+          ### Required: PORTAL_OAUTH2_PROXY_COOKIE_NAME
           cookieName: '{{ env "PORTAL_OAUTH2_PROXY_COOKIE_NAME" }}'
-          ### Required: PORTAL_OAUTH2_PROXY_COOKIE_SECRET;
+          ### Required: PORTAL_OAUTH2_PROXY_COOKIE_SECRET
           cookieSecret: '{{ env "PORTAL_OAUTH2_PROXY_COOKIE_SECRET" }}'
-          ### Required: PORTAL_HOSTNAME;
+          ### Required: PORTAL_HOSTNAME
           cookieDomain: '{{ env "PORTAL_HOSTNAME" }}'
           cookieSecure: true
           cookieHttponly: false
-          ### Optional: PORTAL_OAUTH2_PROXY_REPLICA_COUNT;
+          ### Optional: PORTAL_OAUTH2_PROXY_REPLICA_COUNT
           replicaCount: '{{ env "PORTAL_OAUTH2_PROXY_REPLICA_COUNT" | default "2" }}'
           image:
             repository: "cloudposse/oauth2-proxy"
-            ### Optional: PORTAL_OAUTH2_PROXY_IMAGE_TAG;
+            ### Optional: PORTAL_OAUTH2_PROXY_IMAGE_TAG
             tag: '{{ env "PORTAL_OAUTH2_PROXY_IMAGE_TAG" | default "2.2" }}'
             pullPolicy: "Always"
           resources:

--- a/helmfile.d/0630.kibana.yaml
+++ b/helmfile.d/0630.kibana.yaml
@@ -1,7 +1,6 @@
 helmDefaults:
   args:
   - "--wait"
-  - "--recreate-pods"
   - "--timeout=600"
   - "--force"
   - "--reset-values"
@@ -33,48 +32,48 @@ releases:
   chart: "stable/kibana"
   version: "0.10.0"
   values:
-  - replicaCount: {{ env "KIBANA_REPLICA_COUNT" | default 1 }}
+  - replicaCount: '{{ env "KIBANA_REPLICA_COUNT" | default 1 }}'
     image:
       repository: "docker.elastic.co/kibana/kibana-oss"
-      tag: {{ env "KIBANA_IMAGE_TAG" | default "6.3.1" }}
+      tag: '{{ env "KIBANA_IMAGE_TAG" | default "6.3.1" }}'
       pullPolicy: "IfNotPresent"
     service:
       type: ClusterIP
-      externalPort: 443
-      internalPort: {{ env "KIBANA_SERVER_PORT" | default "5601" }}
+      externalPort: "443"
+      internalPort: '{{ env "KIBANA_SERVER_PORT" | default "5601" }}'
       annotations:
-        iam.amazonaws.com/role: {{ env "ELASTICSEARCH_IAM_ROLE" }}
+        iam.amazonaws.com/role: '{{ env "ELASTICSEARCH_IAM_ROLE" }}'
       labels:
         # Show service URL in `kubectl cluster-info`
         kubernetes.io/cluster-service: "true"
     resources:
       limits:
-        cpu: 500m
-        memory: 1024Mi
+        cpu: "500m"
+        memory: "1024Mi"
       requests:
-        cpu: 200m
-        memory: 512Mi
+        cpu: "200m"
+        memory: "512Mi"
     ingress:
       enabled: "true"
       annotations:
         kubernetes.io/ingress.class: "nginx"
         kubernetes.io/tls-acme: "true"
         external-dns.alpha.kubernetes.io/ttl: "60"
-        external-dns.alpha.kubernetes.io/target: {{ env "KIBANA_INGRESS" }}
-        external-dns.alpha.kubernetes.io/hostname: {{ env "KIBANA_HOSTNAME" }}
+        external-dns.alpha.kubernetes.io/target: '{{ env "KIBANA_INGRESS" }}'
+        external-dns.alpha.kubernetes.io/hostname: '{{ env "KIBANA_HOSTNAME" }}'
       hosts:
-      - {{ env "KIBANA_HOSTNAME" }}
+      - '{{ env "KIBANA_HOSTNAME" }}'
       tls:
-      - secretName: {{ env "KIBANA_SECRET_NAME" | default "kibana-server-tls" }}
+      - secretName: '{{ env "KIBANA_SECRET_NAME" | default "kibana-server-tls" }}'
         hosts:
-        - {{ env "KIBANA_HOSTNAME" }}
+        - '{{ env "KIBANA_HOSTNAME" }}'
     files:
       kibana.yml:
         ## Default Kibana configuration from kibana-docker.
         server:
           name: "kibana"
           host: '{{ env "KIBANA_SERVER_HOST" | default "localhost" }}'
-          port: {{ env "KIBANA_SERVER_PORT" | default "5601" }}
+          port: '{{ env "KIBANA_SERVER_PORT" | default "5601" }}'
           defaultRoute: "/app/kibana"
         elasticsearch:
           url: '{{ env "ELASTICSEARCH_HOST" | default "elasticsearch" }}:{{ env "ELASTICSEARCH_PORT" | default "80" }}'


### PR DESCRIPTION
## what
* Add conditions to portal backends
* Remove `--recreate-pods` parameters

## why
* To enable/disable portal backends. Some backends (e.g. `Kibana` or `Docs`) are not necessary in some cases or for some clients
* `--recreate-pods` causes outages


## test
* `chamber write kops PORTAL_BACKEND_KIBANA_ENABLED true`
![image](https://user-images.githubusercontent.com/7356997/43678010-c6195844-97d9-11e8-9b89-3116e14c4c84.png)

* `chamber write kops PORTAL_BACKEND_KIBANA_ENABLED false`
![image](https://user-images.githubusercontent.com/7356997/43678034-1cfeb9e2-97da-11e8-95db-bf9a1fd99811.png)

 