### PR TITLE
[portal] Update portal to 0.2.2

### DIFF
--- a/helmfile.d/0620.portal.yaml
+++ b/helmfile.d/0620.portal.yaml
@@ -8,7 +8,8 @@ helmDefaults:
 repositories:
 # Cloud Posse incubator repo of helm charts
 - name: "cloudposse-incubator"
-  url: "https://charts.cloudposse.com/incubator/"
+  #  url: "https://charts.cloudposse.com/incubator/"
+  url: "https://charts.dev.cloudposse.com/fix/gh151/portal-url-paths/incubator/"
 
 releases:
 
@@ -31,16 +32,17 @@ releases:
     vendor: "cloudposse"
     default: "true"
   chart: "cloudposse-incubator/portal"
-  version: "0.1.0"
+  version: "0.2.2"
   values:
   - backends:
-      ### Optional: PORTAL_BACKEND_K8S_DASHBOARD_ENABLED
-      {{ if eq (env "PORTAL_BACKEND_K8S_DASHBOARD_ENABLED" | default "true") "true" }}
+      ### Optional: PORTAL_BACKEND_DASHBOARD_ENABLED
+      {{ if eq (env "PORTAL_BACKEND_DASHBOARD_ENABLED" | default "true") "true" }}
       dashboard:
-        ### Optional: PORTAL_BACKEND_K8S_DASHBOARD_NAME
-        name: '{{ env "PORTAL_BACKEND_K8S_DASHBOARD_NAME" | default "Kubernetes" }}'
-        ### Optional: PORTAL_BACKEND_K8S_DASHBOARD_ENDPOINT;
-        endpoint: '{{ env "PORTAL_BACKEND_K8S_DASHBOARD_ENDPOINT" | default "https://kubernetes-dashboard.kube-system:443" }}'
+        ### Optional: PORTAL_BACKEND_DASHBOARD_NAME
+        name: '{{ env "PORTAL_BACKEND_DASHBOARD_NAME" | default "Kubernetes" }}'
+        externalName: 'kubernetes-dashboard.kube-system.svc.cluster.local'
+        servicePort: 443
+        tls: true
         external: false
       {{ end }}
       ### Optional: PORTAL_BACKEND_GRAFANA_ENABLED
@@ -48,8 +50,8 @@ releases:
       grafana:
         ### Optional: PORTAL_BACKEND_GRAFANA_NAME
         name: '{{ env "PORTAL_BACKEND_GRAFANA_NAME" | default "Grafana" }}'
-        ### Optional: PORTAL_BACKEND_GRAFANA_ENDPOINT
-        endpoint: '{{ env "PORTAL_BACKEND_GRAFANA_ENDPOINT" | default "http://kube-prometheus-grafana.monitoring:80" }}'
+        serviceName: 'kube-prometheus-grafana'
+        servicePort: 80
         external: false
       {{ end }}
       ### Optional: PORTAL_BACKEND_ALERTS_ENABLED
@@ -57,8 +59,8 @@ releases:
       alerts:
         ### Optional: PORTAL_BACKEND_ALERTS_NAME
         name: '{{ env "PORTAL_BACKEND_ALERTS_NAME" | default "Alerts" }}'
-        ### Optional: PORTAL_BACKEND_ALERTS_ENDPOINT
-        endpoint: '{{ env "PORTAL_BACKEND_ALERTS_ENDPOINT" | default "http://kube-prometheus-alertmanager.monitoring:9093" }}'
+        serviceName: 'kube-prometheus-alertmanager'
+        servicePort: 9093
         external: false
       {{ end }}
       ### Optional: PORTAL_BACKEND_PROMETHEUS_ENABLED
@@ -66,8 +68,8 @@ releases:
       prometheus:
         ### Optional: PORTAL_BACKEND_PROMETHEUS_NAME
         name: '{{ env "PORTAL_BACKEND_PROMETHEUS_NAME" | default "Prometheus" }}'
-        ### Optional: PORTAL_BACKEND_PROMETHEUS_ENDPOINT
-        endpoint: '{{ env "PORTAL_BACKEND_PROMETHEUS_ENDPOINT" | default "http://kube-prometheus-prometheus.monitoring:9090" }}'
+        serviceName: 'kube-prometheus-prometheus'
+        servicePort: 9090
         external: false
       {{ end }}
       ### Optional: PORTAL_BACKEND_DOCS_ENABLED
@@ -85,7 +87,10 @@ releases:
         ### Optional: PORTAL_BACKEND_KIBANA_NAME
         name: '{{ env "PORTAL_BACKEND_KIBANA_NAME" | default "Kibana" }}'
         ### Optional: PORTAL_BACKEND_KIBANA_ENDPOINT
-        endpoint: '{{ env "PORTAL_BACKEND_KIBANA_ENDPOINT" | default "http://kibana.monitoring:80" }}'
+        externalName: '{{ env "PORTAL_BACKEND_KIBANA_EXTERNAL_NAME" | default "kibana.monitoring" }}'
+        servicePort: 443
+        path: '/_plugin/kibana'
+        tls: true
         external: false
       {{ end }}
   - config:

--- a/helmfile.d/0620.portal.yaml
+++ b/helmfile.d/0620.portal.yaml
@@ -8,8 +8,7 @@ helmDefaults:
 repositories:
 # Cloud Posse incubator repo of helm charts
 - name: "cloudposse-incubator"
-  #  url: "https://charts.cloudposse.com/incubator/"
-  url: "https://charts.dev.cloudposse.com/fix/gh151/portal-url-paths/incubator/"
+  url: "https://charts.cloudposse.com/incubator/"
 
 releases:
 

--- a/helmfile.d/0620.portal.yaml
+++ b/helmfile.d/0620.portal.yaml
@@ -40,8 +40,8 @@ releases:
       dashboard:
         ### Optional: PORTAL_BACKEND_DASHBOARD_NAME
         name: '{{ env "PORTAL_BACKEND_DASHBOARD_NAME" | default "Kubernetes" }}'
-        externalName: 'kubernetes-dashboard.kube-system.svc.cluster.local'
-        servicePort: 443
+        externalName: '{{ env "PORTAL_BACKEND_DASHBOARD_SERVICE_NAME" | default "kubernetes-dashboard.kube-system.svc.cluster.local" }}'
+        servicePort: '{{ env "PORTAL_BACKEND_DASHBOARD_SERVICE_PORT" | default "443" }}'
         tls: true
         external: false
       {{ end }}
@@ -50,8 +50,10 @@ releases:
       grafana:
         ### Optional: PORTAL_BACKEND_GRAFANA_NAME
         name: '{{ env "PORTAL_BACKEND_GRAFANA_NAME" | default "Grafana" }}'
-        serviceName: 'kube-prometheus-grafana'
-        servicePort: 80
+        ### Optional: PORTAL_BACKEND_GRAFANA_SERVICE_NAME
+        serviceName: '{{ env "PORTAL_BACKEND_GRAFANA_SERVICE_NAME" | default "kube-prometheus-grafana" }}'
+        ### Optional: PORTAL_BACKEND_GRAFANA_SERVICE_PORT
+        servicePort: '{{ env "PORTAL_BACKEND_GRAFANA_SERVICE_PORT" | default "80" }}'
         external: false
       {{ end }}
       ### Optional: PORTAL_BACKEND_ALERTS_ENABLED
@@ -59,8 +61,10 @@ releases:
       alerts:
         ### Optional: PORTAL_BACKEND_ALERTS_NAME
         name: '{{ env "PORTAL_BACKEND_ALERTS_NAME" | default "Alerts" }}'
-        serviceName: 'kube-prometheus-alertmanager'
-        servicePort: 9093
+        ### Optional: PORTAL_BACKEND_ALERTS_SERVICE_NAME
+        serviceName: '{{ env "PORTAL_BACKEND_ALERTS_SERVICE_NAME" | default "kube-prometheus-alertmanager" }}'
+        ### Optional: PORTAL_BACKEND_ALERTS_SERVICE_PORT
+        servicePort: '{{ env "PORTAL_BACKEND_ALERTS_SERVICE_PORT" | default "9093" }}'
         external: false
       {{ end }}
       ### Optional: PORTAL_BACKEND_PROMETHEUS_ENABLED
@@ -68,8 +72,10 @@ releases:
       prometheus:
         ### Optional: PORTAL_BACKEND_PROMETHEUS_NAME
         name: '{{ env "PORTAL_BACKEND_PROMETHEUS_NAME" | default "Prometheus" }}'
-        serviceName: 'kube-prometheus-prometheus'
-        servicePort: 9090
+        ### Optional: PORTAL_BACKEND_PROMETHEUS_SERVICE_NAME
+        serviceName: '{{ env "PORTAL_BACKEND_PROMETHEUS_SERVICE_NAME" | default "kube-prometheus-prometheus" }}'
+        ### Optional: PORTAL_BACKEND_PROMETHEUS_SERVICE_PORT
+        servicePort: '{{ env "PORTAL_BACKEND_PROMETHEUS_SERVICE_PORT" | default "9090" }}'
         external: false
       {{ end }}
       ### Optional: PORTAL_BACKEND_DOCS_ENABLED
@@ -86,10 +92,12 @@ releases:
       kibana:
         ### Optional: PORTAL_BACKEND_KIBANA_NAME
         name: '{{ env "PORTAL_BACKEND_KIBANA_NAME" | default "Kibana" }}'
-        ### Optional: PORTAL_BACKEND_KIBANA_ENDPOINT
+        ### Optional: PORTAL_BACKEND_KIBANA_EXTERNAL_NAME
         externalName: '{{ env "PORTAL_BACKEND_KIBANA_EXTERNAL_NAME" | default "kibana.monitoring" }}'
-        servicePort: 443
-        path: '/_plugin/kibana'
+        ### Optional: PORTAL_BACKEND_KIBANA_SERVICE_PORT
+        servicePort: '{{ env "PORTAL_BACKEND_KIBANA_SERVICE_PORT" | default "443" }}'
+        ### Optional: PORTAL_BACKEND_KIBANA_PATH
+        path: '{{ env "PORTAL_BACKEND_KIBANA_PATH" | default "/_plugin/kibana" }}'
         tls: true
         external: false
       {{ end }}


### PR DESCRIPTION
## what
* Upgrade portal to `0.2.2`
* Deprecate endpoint as no longer used
* Introduce `externalName`
* Support `path` parameter

## why
* Previous portal relied on a custom traefik implementation
* This uses native ingress
* Support paths for kibana

## upgrading
* All previous `*_ENDPOINT` envs are deprecated
* Use `..._SERVICE_NAME`, `.._SERVICE_PORT` and `..._EXTERNAL_NAME` instead

## references
- <https://github.com/cloudposse/charts/pull/152>
- <https://github.com/cloudposse/geodesic/issues/191>