### PR TITLE
[chartmuseum] add `CHARTMUSEUM_TLS_ENABLED` flag

### DIFF
--- a/helmfile.d/0300.chartmuseum.yaml
+++ b/helmfile.d/0300.chartmuseum.yaml
@@ -77,9 +77,12 @@ releases:
             - "/charts"
             ### Required: CHARTMUSEUM_HOSTNAME; e.g. charts.us-west-2.staging.cloudposse.org
             - "/index.yaml"
+        ### Optional: CHARTMUSEUM_TLS_ENABLED;
+        {{- if env "CHARTMUSEUM_TLS_ENABLED" | default "true" | eq "true" }}
         tls:
             ### Optional: CHARTMUSEUM_SECRET_NAME; e.g. chartmuseum-server-tls
           - secretName: '{{ env "CHARTMUSEUM_SECRET_NAME" | default "chartmuseum-server-tls" }}'
             ### Required: CHARTMUSEUM_HOSTNAME; e.g. charts.us-west-2.staging.cloudposse.org
             hosts:
               - '{{ env "CHARTMUSEUM_HOSTNAME" }}'
+        {{- end }}

--- a/helmfile.d/0310.chartmuseum-api.yaml
+++ b/helmfile.d/0310.chartmuseum-api.yaml
@@ -73,9 +73,12 @@ releases:
           '{{ env "CHARTMUSEUM_API_HOSTNAME" }}':
             ### Required: CHARTMUSEUM_API_HOSTNAME; e.g. api.charts.us-west-2.staging.cloudposse.org
             - "/api"
+        ### Optional: CHARTMUSEUM_API_TLS_ENABLED;
+        {{- if env "CHARTMUSEUM_API_TLS_ENABLED" | default "true" | eq "true" }}
         tls:
-            ### Optional: CHARTMUSEUM_SECRET_NAME; e.g. chartmuseum-server-tls
-          - secretName: '{{ env "CHARTMUSEUM_SECRET_NAME" | default "chartmuseum-server-tls" }}'
+            ### Optional: CHARTMUSEUM_API_SECRET_NAME; e.g. chartmuseum-api-server-tls
+          - secretName: '{{ env "CHARTMUSEUM_API_SECRET_NAME" | default "chartmuseum-api-server-tls" }}'
             ### Required: CHARTMUSEUM_API_HOSTNAME; e.g. api.charts.us-west-2.staging.cloudposse.org
             hosts:
               - '{{ env "CHARTMUSEUM_API_HOSTNAME" }}'
+        {{- end }}


### PR DESCRIPTION
## what 
* add check if TLS enabled to hide values for chartmuseum and chartmuseum-api
* fix CHARTMUSEUM_API_SECRET_NAME env

## why
#10 

## upgrading

Rename `CHARTMUSEUM_SECRET_NAME` to `CHARTMUSEUM_API_SECRET_NAME`