### PR TITLE
Add `repo` label to helmfiles

### DIFF
--- a/helmfile.d/0000.kube2iam.yaml
+++ b/helmfile.d/0000.kube2iam.yaml
@@ -24,6 +24,7 @@ releases:
   namespace: "kube-system"
   labels:
     chart: "kube2iam"
+    repo: "stable"
     component: "iam"
     namespace: "kube-system"
     vendor: "jtblin"

--- a/helmfile.d/0010.kiam.yaml
+++ b/helmfile.d/0010.kiam.yaml
@@ -25,6 +25,7 @@ releases:
   namespace: "kube-system"
   labels:
     chart: "kiam"
+    repo: "stable"
     component: "iam"
     namespace: "kube-system"
     vendor: "uswitch"
@@ -65,7 +66,7 @@ releases:
           - name: "ssl-certs"
             mountPath: "/etc/ssl/certs"
             hostPath: '{{ env "KIAM_HOST_CERT_PATH" | default "/etc/ssl/certs" }}'
-            readOnly: true 
+            readOnly: true
         tlsFiles:
           ### Required: KIAM_AGENT_TLS_CA; e.g. base64-encoded ca.pem
           ca: '{{ env "KIAM_SERVER_TLS_CA" }}'

--- a/helmfile.d/0100.external-dns.yaml
+++ b/helmfile.d/0100.external-dns.yaml
@@ -24,6 +24,7 @@ releases:
   namespace: "kube-system"
   labels:
     chart: "external-dns"
+    repo: "stable"
     component: "ingress"
     namespace: "kube-system"
     vendor: "kubernetes-incubator"

--- a/helmfile.d/0110.kube-lego.yaml
+++ b/helmfile.d/0110.kube-lego.yaml
@@ -25,7 +25,7 @@ releases:
   namespace: "kube-system"
   labels:
     chart: "kube-lego"
-    repo: "stable"
+    repo: "cloudposse-incubator"
     component: "ingress"
     namespace: "kube-system"
     vendor: "jetstack"

--- a/helmfile.d/0110.kube-lego.yaml
+++ b/helmfile.d/0110.kube-lego.yaml
@@ -25,6 +25,7 @@ releases:
   namespace: "kube-system"
   labels:
     chart: "kube-lego"
+    repo: "stable"
     component: "ingress"
     namespace: "kube-system"
     vendor: "jetstack"

--- a/helmfile.d/0120.cert-manager.yaml
+++ b/helmfile.d/0120.cert-manager.yaml
@@ -1,7 +1,7 @@
 helmDefaults:
   args:
     - "--wait"
-    - "--timeout=600" 
+    - "--timeout=600"
     - "--force"
     - "--reset-values"
 
@@ -21,6 +21,7 @@ releases:
   namespace: "kube-system"
   labels:
     chart: "cert-manager"
+    repo: "stable"
     component: "ingress"
     namespace: "kube-system"
     vendor: "jetstack"

--- a/helmfile.d/0300.chartmuseum.yaml
+++ b/helmfile.d/0300.chartmuseum.yaml
@@ -20,6 +20,7 @@ releases:
   namespace: "kube-system"
   labels:
     chart: "chartmuseum"
+    repo: "stable"
     component: "platform"
     namespace: "kube-system"
     vendor: "kubernetes-helm"

--- a/helmfile.d/0310.chartmuseum-api.yaml
+++ b/helmfile.d/0310.chartmuseum-api.yaml
@@ -20,6 +20,7 @@ releases:
   namespace: "kube-system"
   labels:
     chart: "chartmuseum"
+    repo: "stable"
     component: "platform"
     namespace: "kube-system"
     vendor: "kubernetes-helm"

--- a/helmfile.d/0320.nginx-ingress.yaml
+++ b/helmfile.d/0320.nginx-ingress.yaml
@@ -24,6 +24,7 @@ releases:
   namespace: "kube-system"
   labels:
     chart: "nginx-ingress"
+    repo: "cloudposse-incubator"
     component: "ingress"
     namespace: "kube-system"
     vendor: "kubernetes"

--- a/helmfile.d/0330.stable-nginx-ingress.yaml
+++ b/helmfile.d/0330.stable-nginx-ingress.yaml
@@ -20,10 +20,11 @@ releases:
 # References:
 #   - https://github.com/cloudposse/charts/blob/master/incubator/nginx-ingress/values.yaml
 #
-- name: "stable-ingress"
+- name: "ingress"
   namespace: "kube-system"
   labels:
     chart: "nginx-ingress"
+    repo: "stable"
     component: "ingress"
     namespace: "kube-system"
     vendor: "kubernetes"

--- a/helmfile.d/0330.stable-nginx-ingress.yaml
+++ b/helmfile.d/0330.stable-nginx-ingress.yaml
@@ -20,7 +20,7 @@ releases:
 # References:
 #   - https://github.com/cloudposse/charts/blob/master/incubator/nginx-ingress/values.yaml
 #
-- name: "ingress"
+- name: "stable-ingress"
   namespace: "kube-system"
   labels:
     chart: "nginx-ingress"

--- a/helmfile.d/0400.prometheus-operator.yaml
+++ b/helmfile.d/0400.prometheus-operator.yaml
@@ -26,6 +26,7 @@ releases:
   namespace: "kube-system"
   labels:
     chart: "prometheus-operator"
+    repo: "coreos-stable"
     component: "monitoring"
     namespace: "kube-system"
     vendor: "coreos"

--- a/helmfile.d/0410.kube-prometheus.yaml
+++ b/helmfile.d/0410.kube-prometheus.yaml
@@ -1,7 +1,7 @@
 helmDefaults:
   args:
     - "--wait"
-    - "--timeout=600" 
+    - "--timeout=600"
     - "--force"
     - "--reset-values"
 
@@ -32,6 +32,7 @@ releases:
   namespace: "monitoring"
   labels:
     chart: "kube-prometheus"
+    repo: "coreos-stable"
     component: "monitoring"
     namespace: "monitoring"
     vendor: "coreos"

--- a/helmfile.d/0420.grafana.yaml
+++ b/helmfile.d/0420.grafana.yaml
@@ -1,7 +1,7 @@
 helmDefaults:
   args:
     - "--wait"
-    - "--timeout=600" 
+    - "--timeout=600"
     - "--force"
     - "--reset-values"
 
@@ -20,6 +20,7 @@ releases:
   namespace: "monitoring"
   labels:
     chart: "grafana"
+    repo: "stable"
     component: "monitoring"
     namespace: "monitoring"
     vendor: "kubernetes"

--- a/helmfile.d/0500.datalog.yaml
+++ b/helmfile.d/0500.datalog.yaml
@@ -26,6 +26,7 @@ releases:
   namespace: "monitoring"
   labels:
     chart: "datadog"
+    repo: "stable"
     component: "monitoring"
     namespace: "monitoring"
     vendor: "datadog"

--- a/helmfile.d/0510.fluentd-datadog-logs.yaml
+++ b/helmfile.d/0510.fluentd-datadog-logs.yaml
@@ -29,6 +29,7 @@ releases:
   namespace: "kube-system"
   labels:
     chart: "fluentd-kubernetes"
+    repo: "cloudposse-incubator"
     component: "datadog"
     namespace: "kube-system"
     default: "false"

--- a/helmfile.d/0520.fluentd-elasticsearch-logs.yaml
+++ b/helmfile.d/0520.fluentd-elasticsearch-logs.yaml
@@ -26,6 +26,7 @@ releases:
   namespace: "kube-system"
   labels:
     chart: "fluentd-kubernetes"
+    repo: "cloudposse-incubator"
     component: "elasticsearch"
     namespace: "kube-system"
     default: "false"

--- a/helmfile.d/0600.heapster.yaml
+++ b/helmfile.d/0600.heapster.yaml
@@ -26,6 +26,7 @@ releases:
   namespace: "kube-system"
   labels:
     chart: "heapster"
+    repo: "stable"
     component: "monitoring"
     namespace: "kube-system"
     vendor: "kubernetes"

--- a/helmfile.d/0610.dashboard.yaml
+++ b/helmfile.d/0610.dashboard.yaml
@@ -26,6 +26,7 @@ releases:
   namespace: "kube-system"
   labels:
     chart: "kubernetes-dashboard"
+    repo: "stable"
     component: "monitoring"
     namespace: "kube-system"
     vendor: "kubernetes"

--- a/helmfile.d/0620.portal.yaml
+++ b/helmfile.d/0620.portal.yaml
@@ -26,6 +26,7 @@ releases:
   namespace: "monitoring"
   labels:
     chart: "portal"
+    repo: "cloudposse-incubator"
     component: "monitoring"
     namespace: "monitoring"
     vendor: "cloudposse"

--- a/helmfile.d/0630.kibana.yaml
+++ b/helmfile.d/0630.kibana.yaml
@@ -25,6 +25,7 @@ releases:
   namespace: "monitoring"
   labels:
     chart: "kibana"
+    repo: "stable"
     component: "monitoring"
     namespace: "monitoring"
     vendor: "kubernetes-helm"


### PR DESCRIPTION
## what
* Add `repo` label to helmfiles

## why
* When we have multiple helmfiles with the same release and chart names, to be able to deploy charts by the name and repo, e.g. `helmfile --selector chart=nginx-ingress,repo=stable`
