### PR TITLE
Deprecate helmDefaults. Use wait true

### DIFF
--- a/helmfile.d/0000.kube2iam.yaml
+++ b/helmfile.d/0000.kube2iam.yaml
@@ -1,10 +1,3 @@
-helmDefaults:
-  args:
-    - "--wait"
-    - "--timeout=600"
-    - "--force"
-    - "--reset-values"
-
 repositories:
 # Stable repo of official helm charts
 - name: "stable"
@@ -31,6 +24,7 @@ releases:
     default: "false"
   chart: "stable/kube2iam"
   version: "0.8.5"
+  wait: true
   values:
     - tolerations:
         - key: "node-role.kubernetes.io/master"

--- a/helmfile.d/0010.kiam.yaml
+++ b/helmfile.d/0010.kiam.yaml
@@ -1,10 +1,3 @@
-helmDefaults:
-  args:
-    - "--wait"
-    - "--timeout=600"
-    - "--force"
-    - "--reset-values"
-
 repositories:
 # Stable repo of official helm charts
 - name: "stable"
@@ -32,6 +25,7 @@ releases:
     default: "true"
   chart: "stable/kiam"
   version: "1.0.0"
+  wait: true
   values:
     - rbac:
         create: {{ env "KIAM_RBAC_CREATE" | default "false" }}

--- a/helmfile.d/0100.external-dns.yaml
+++ b/helmfile.d/0100.external-dns.yaml
@@ -1,10 +1,3 @@
-helmDefaults:
-  args:
-    - "--wait"
-    - "--timeout=600"
-    - "--force"
-    - "--reset-values"
-
 repositories:
 # Stable repo of official helm charts
 - name: "stable"
@@ -31,6 +24,7 @@ releases:
     default: "true"
   chart: "stable/external-dns"
   version: "0.5.4"
+  wait: true
   values:
     - extraEnv:
         EXTERNAL_DNS_SOURCE: "service\ningress"

--- a/helmfile.d/0110.kube-lego.yaml
+++ b/helmfile.d/0110.kube-lego.yaml
@@ -1,10 +1,3 @@
-helmDefaults:
-  args:
-    - "--wait"
-    - "--timeout=600"
-    - "--force"
-    - "--reset-values"
-
 repositories:
 # Cloud Posse incubator repo of helm charts
 - name: "cloudposse-incubator"
@@ -32,6 +25,7 @@ releases:
     default: "true"
   chart: "cloudposse-incubator/kube-lego"
   version: "0.1.2"
+  wait: true
   values:
     - image:
         repository: "jetstack/kube-lego"

--- a/helmfile.d/0120.cert-manager.yaml
+++ b/helmfile.d/0120.cert-manager.yaml
@@ -1,10 +1,3 @@
-helmDefaults:
-  args:
-    - "--wait"
-    - "--timeout=600"
-    - "--force"
-    - "--reset-values"
-
 repositories:
 # Stable repo of official helm charts
 - name: "stable"
@@ -28,6 +21,7 @@ releases:
     default: "false"
   chart: "stable/cert-manager"
   version: "v0.4.0"
+  wait: true
   values:
     - rbac:
         ### Optional: CERT_MANAGER_RBAC_CREATE;

--- a/helmfile.d/0300.chartmuseum.yaml
+++ b/helmfile.d/0300.chartmuseum.yaml
@@ -1,10 +1,3 @@
-helmDefaults:
-  args:
-    - "--wait"
-    - "--timeout=600"
-    - "--force"
-    - "--reset-values"
-
 repositories:
 # Stable repo of official helm charts
 - name: "stable"
@@ -27,6 +20,7 @@ releases:
     default: "true"
   chart: "stable/chartmuseum"
   version: "1.4.0"
+  wait: true
   values:
     - replicaCount: 1
       env:

--- a/helmfile.d/0310.chartmuseum-api.yaml
+++ b/helmfile.d/0310.chartmuseum-api.yaml
@@ -1,10 +1,3 @@
-helmDefaults:
-  args:
-    - "--wait"
-    - "--timeout=600"
-    - "--force"
-    - "--reset-values"
-
 repositories:
 # Stable repo of official helm charts
 - name: "stable"
@@ -27,6 +20,7 @@ releases:
     default: "true"
   chart: "stable/chartmuseum"
   version: "1.4.0"
+  wait: true
   values:
     - replicaCount: "1"
       env:

--- a/helmfile.d/0320.nginx-ingress.yaml
+++ b/helmfile.d/0320.nginx-ingress.yaml
@@ -1,10 +1,3 @@
-helmDefaults:
-  args:
-    - "--wait"
-    - "--timeout=600"
-    - "--force"
-    - "--reset-values"
-
 repositories:
 # Cloud Posse incubator repo of helm charts
 - name: "cloudposse-incubator"
@@ -31,6 +24,7 @@ releases:
     default: "true"
   chart: "cloudposse-incubator/nginx-ingress"
   version: "0.1.7"
+  wait: true
   values:
     - image:
         repository: "quay.io/kubernetes-ingress-controller/nginx-ingress-controller"

--- a/helmfile.d/0330.stable-nginx-ingress.yaml
+++ b/helmfile.d/0330.stable-nginx-ingress.yaml
@@ -1,10 +1,3 @@
-helmDefaults:
-  args:
-    - "--wait"
-    - "--timeout=600"
-    - "--force"
-    - "--reset-values"
-
 repositories:
 # Stable repo of official helm charts
 - name: "stable"
@@ -31,6 +24,7 @@ releases:
     default: "false"
   chart: "stable/nginx-ingress"
   version: "0.24.0"
+  wait: true
   values:
     - controller:
         ### Optional: NGINX_INGRESS_CONTROLLER_REPLICA_COUNT; e.g. 2

--- a/helmfile.d/0400.prometheus-operator.yaml
+++ b/helmfile.d/0400.prometheus-operator.yaml
@@ -1,10 +1,3 @@
-helmDefaults:
-  args:
-    - "--wait"
-    - "--timeout=600"
-    - "--force"
-    - "--reset-values"
-
 repositories:
 # CoreOS Stable helm charts
 - name: "coreos-stable"
@@ -33,6 +26,7 @@ releases:
     default: "true"
   chart: "coreos-stable/prometheus-operator"
   version: "0.0.23"
+  wait: true
   values:
     - rbacEnable: false
       jobLabel: "prometheus-operator"

--- a/helmfile.d/0410.kube-prometheus.yaml
+++ b/helmfile.d/0410.kube-prometheus.yaml
@@ -1,10 +1,3 @@
-helmDefaults:
-  args:
-    - "--wait"
-    - "--timeout=600"
-    - "--force"
-    - "--reset-values"
-
 repositories:
 # CoreOS Stable helm charts
 - name: "coreos-stable"
@@ -39,6 +32,7 @@ releases:
     default: "true"
   chart: "coreos-stable/kube-prometheus"
   version: "0.0.66"
+  wait: true
   values:
     ### Optional: KUBE_PROMETHEUS_EXTERNAL_VALUES_FILE;
     - '{{ env "KUBE_PROMETHEUS_EXTERNAL_VALUES_FILE" | default "values/kube-prometheus.grafana.dashboards.yaml" }}'

--- a/helmfile.d/0420.grafana.yaml
+++ b/helmfile.d/0420.grafana.yaml
@@ -1,10 +1,3 @@
-helmDefaults:
-  args:
-    - "--wait"
-    - "--timeout=600"
-    - "--force"
-    - "--reset-values"
-
 repositories:
 # Stable repo of official helm charts
 - name: "stable"
@@ -27,6 +20,7 @@ releases:
     default: "false"
   chart: "stable/grafana"
   version: "1.12.0"
+  wait: true
   values:
     ### Optional: GRAFANA_EXTERNAL_VALUES_FILE;
     - '{{ env "GRAFANA_EXTERNAL_VALUES_FILE" | default "values/grafana.dashboards.yaml" }}'

--- a/helmfile.d/0500.datalog.yaml
+++ b/helmfile.d/0500.datalog.yaml
@@ -1,10 +1,3 @@
-helmDefaults:
-  args:
-    - "--wait"
-    - "--timeout=600"
-    - "--force"
-    - "--reset-values"
-
 repositories:
 # Stable repo of official helm charts
 - name: "stable"
@@ -33,6 +26,7 @@ releases:
     default: "false"
   chart: "stable/datadog"
   version: "0.16.0"
+  wait: true
   values:
     - image:
         repository: "datadog/agent"

--- a/helmfile.d/0510.fluentd-datadog-logs.yaml
+++ b/helmfile.d/0510.fluentd-datadog-logs.yaml
@@ -1,10 +1,3 @@
-helmDefaults:
-  args:
-  - "--wait"
-  - "--timeout=600"
-  - "--force"
-  - "--reset-values"
-
 repositories:
 # Incubator repo of official helm charts
 # Cloud Posse incubator repo of helm charts
@@ -35,6 +28,7 @@ releases:
     default: "false"
   chart: "cloudposse-incubator/fluentd-kubernetes"
   version: "0.2.0"
+  wait: true
   values:
   - image:
       repository: "cloudposse/fluentd-datadog-logs"

--- a/helmfile.d/0520.fluentd-elasticsearch-logs.yaml
+++ b/helmfile.d/0520.fluentd-elasticsearch-logs.yaml
@@ -1,10 +1,3 @@
-helmDefaults:
-  args:
-  - "--wait"
-  - "--timeout=600"
-  - "--force"
-  - "--reset-values"
-
 repositories:
 # Cloud Posse incubator repo of helm charts
 - name: "cloudposse-incubator"
@@ -32,6 +25,7 @@ releases:
     default: "false"
   chart: "cloudposse-incubator/fluentd-kubernetes"
   version: "0.3.0"
+  wait: true
   values:
   - image:
       repository: "fluent/fluentd-kubernetes-daemonset"

--- a/helmfile.d/0600.heapster.yaml
+++ b/helmfile.d/0600.heapster.yaml
@@ -1,10 +1,3 @@
-helmDefaults:
-  args:
-    - "--wait"
-    - "--timeout=600"
-    - "--force"
-    - "--reset-values"
-
 repositories:
 # Stable repo of official helm charts
 - name: "stable"
@@ -33,6 +26,7 @@ releases:
     default: "true"
   chart: "stable/heapster"
   version: "0.2.10"
+  wait: true
   values:
       ### Optional: HEAPSTER_REPLICA_COUNT;
     - replicaCount: '{{ env "HEAPSTER_REPLICA_COUNT" | default "1" }}'

--- a/helmfile.d/0610.dashboard.yaml
+++ b/helmfile.d/0610.dashboard.yaml
@@ -1,10 +1,3 @@
-helmDefaults:
-  args:
-    - "--wait"
-    - "--timeout=600"
-    - "--force"
-    - "--reset-values"
-
 repositories:
 # Stable repo of official helm charts
 - name: "stable"
@@ -33,6 +26,7 @@ releases:
     default: "true"
   chart: "stable/kubernetes-dashboard"
   version: "0.6.7"
+  wait: true
   values:
     - image:
         repository: "k8s.gcr.io/kubernetes-dashboard-amd64"

--- a/helmfile.d/0620.portal.yaml
+++ b/helmfile.d/0620.portal.yaml
@@ -1,10 +1,3 @@
-helmDefaults:
-  args:
-  - "--wait"
-  - "--timeout=600"
-  - "--force"
-  - "--reset-values"
-
 repositories:
 # Cloud Posse incubator repo of helm charts
 - name: "cloudposse-incubator"
@@ -33,6 +26,7 @@ releases:
     default: "true"
   chart: "cloudposse-incubator/portal"
   version: "0.1.0"
+  wait: true
   values:
   - backends:
       ### Optional: PORTAL_BACKEND_K8S_DASHBOARD_ENABLED

--- a/helmfile.d/0630.kibana.yaml
+++ b/helmfile.d/0630.kibana.yaml
@@ -1,10 +1,3 @@
-helmDefaults:
-  args:
-  - "--wait"
-  - "--timeout=600"
-  - "--force"
-  - "--reset-values"
-
 repositories:
 # Stable repo of official helm charts
 - name: "stable"
@@ -32,6 +25,7 @@ releases:
     default: "false"
   chart: "stable/kibana"
   version: "0.10.0"
+  wait: true
   values:
   - replicaCount: '{{ env "KIBANA_REPLICA_COUNT" | default 1 }}'
     image:


### PR DESCRIPTION
## what
* Deprecate `helmDefaults` 
* Use `wait: true` (inplace of `--wait`)

## why
* `helmDefaults` break interoperability with helm plugins (E.g. `helm diff`)
* Not absolutely essential

## references
* https://github.com/cloudposse/helmfiles/issues/32
* https://github.com/cloudposse/packages/pull/53