### PR TITLE
[nginx] Add support for TCP/UDP ports

### DIFF
--- a/helmfile.d/0320.nginx-ingress.yaml
+++ b/helmfile.d/0320.nginx-ingress.yaml
@@ -60,6 +60,15 @@ releases:
           enabled: {{ env "NGINX_INGRESS_METRICS_ENABLED" | default "false" }}
         metrics:
           enabled: {{ env "NGINX_INGRESS_METRICS_ENABLED" | default "false" }}
+      tcp:
+      {{- range env "NGINX_INGRESS_TCP" | splitList "," }}
+        {{ regexReplaceAll "(\\d*):(.*)" . "$1: $2" }}
+      {{- end }}
+      udp:
+      {{- range env "NGINX_INGRESS_UDP" | splitList "," }}
+        {{ regexReplaceAll "(\\d*):(.*)" . "$1: $2" }}
+      {{- end }}
+
       defaultBackend:
         enabled: false
       rbac:

--- a/helmfile.d/0320.nginx-ingress.yaml
+++ b/helmfile.d/0320.nginx-ingress.yaml
@@ -60,11 +60,21 @@ releases:
           enabled: {{ env "NGINX_INGRESS_METRICS_ENABLED" | default "false" }}
         metrics:
           enabled: {{ env "NGINX_INGRESS_METRICS_ENABLED" | default "false" }}
+      ### Regexp used to map
+      ### 8080:default/example-tcp-svc:9000,8081:staging/example-tcp-svc:9000
+      ### to
+      ### 8080: default/example-tcp-svc:9000
+      ### 8081: staging/example-tcp-svc:9000
       ### Optional: NGINX_INGRESS_TCP; e.g. 8080:default/example-tcp-svc:9000,8081:staging/example-tcp-svc:9000
       tcp:
       {{- range env "NGINX_INGRESS_TCP" | splitList "," }}
         {{ regexReplaceAll "(\\d*:)(.*)" . "$1 $2" }}
       {{- end }}
+      ### Regexp used to map
+      ### 8080:default/example-udp-svc:9000,8081:staging/example-udp-svc:9000
+      ### to
+      ### 8080: default/example-udp-svc:9000
+      ### 8081: staging/example-udp-svc:9000
       ### Optional: NGINX_INGRESS_UDP; e.g. 8080:default/example-udp-svc:9000,8081:staging/example-udp-svc:9000
       udp:
       {{- range env "NGINX_INGRESS_UDP" | splitList "," }}

--- a/helmfile.d/0320.nginx-ingress.yaml
+++ b/helmfile.d/0320.nginx-ingress.yaml
@@ -63,12 +63,12 @@ releases:
       ### Optional: NGINX_INGRESS_TCP; e.g. 8080:default/example-tcp-svc:9000,8081:staging/example-tcp-svc:9000
       tcp:
       {{- range env "NGINX_INGRESS_TCP" | splitList "," }}
-        {{ regexReplaceAll "(\\d*):(.*)" . "$1: $2" }}
+        {{ regexReplaceAll "(\\d*:)(.*)" . "$1 $2" }}
       {{- end }}
       ### Optional: NGINX_INGRESS_UDP; e.g. 8080:default/example-udp-svc:9000,8081:staging/example-udp-svc:9000
       udp:
       {{- range env "NGINX_INGRESS_UDP" | splitList "," }}
-        {{ regexReplaceAll "(\\d*):(.*)" . "$1: $2" }}
+        {{ regexReplaceAll "(\\d*:)(.*)" . "$1 $2" }}
       {{- end }}
 
       defaultBackend:

--- a/helmfile.d/0320.nginx-ingress.yaml
+++ b/helmfile.d/0320.nginx-ingress.yaml
@@ -60,10 +60,12 @@ releases:
           enabled: {{ env "NGINX_INGRESS_METRICS_ENABLED" | default "false" }}
         metrics:
           enabled: {{ env "NGINX_INGRESS_METRICS_ENABLED" | default "false" }}
+      ### Optional: NGINX_INGRESS_TCP; e.g. 8080:default/example-tcp-svc:9000,8081:staging/example-tcp-svc:9000
       tcp:
       {{- range env "NGINX_INGRESS_TCP" | splitList "," }}
         {{ regexReplaceAll "(\\d*):(.*)" . "$1: $2" }}
       {{- end }}
+      ### Optional: NGINX_INGRESS_UDP; e.g. 8080:default/example-udp-svc:9000,8081:staging/example-udp-svc:9000
       udp:
       {{- range env "NGINX_INGRESS_UDP" | splitList "," }}
         {{ regexReplaceAll "(\\d*):(.*)" . "$1: $2" }}


### PR DESCRIPTION
## What
* Provide env vars to proxy `tcp` and `udp`

## Why
* Expose non-http services via ingress
