### PR TITLE
Added pagerduty alerts

### DIFF
--- a/helmfile.d/0000.prometheus-operator.yaml
+++ b/helmfile.d/0000.prometheus-operator.yaml
@@ -33,7 +33,7 @@ releases:
       image:
         repository: "quay.io/coreos/prometheus-operator"
         ### Optional: PROMETHEUS_OPERATOR_IMAGE_TAG; e.g. v0.20.0
-        tag: '{{ env "PROMETHEUS_OPERATOR_IMAGE_TAG" | default "v0.20.0" }}'
+        tag: '{{ env "PROMETHEUS_OPERATOR_IMAGE_TAG" | default "v0.23.2" }}'
         pullPolicy: "IfNotPresent"
       resources:
         limits:
@@ -51,7 +51,7 @@ releases:
       prometheusConfigReloader:
         repository: "quay.io/coreos/prometheus-config-reloader"
         ### Optional: PROMETHEUS_OPERATOR_PROMETHEUS_CONFIG_RELOADER_IMAGE_TAG; e.g. v0.20.0
-        tag: '{{ env "PROMETHEUS_OPERATOR_PROMETHEUS_CONFIG_RELOADER_IMAGE_TAG" | default "v0.20.0" }}'
+        tag: '{{ env "PROMETHEUS_OPERATOR_PROMETHEUS_CONFIG_RELOADER_IMAGE_TAG" | default "v0.23.2" }}'
       configmapReload:
         repository: "quay.io/coreos/configmap-reload"
         ### Optional: PROMETHEUS_OPERATOR_CONFIGMAP_RELOAD_IMAGE_TAG; e.g. v0.0.1

--- a/helmfile.d/0400.kube-prometheus.yaml
+++ b/helmfile.d/0400.kube-prometheus.yaml
@@ -116,9 +116,12 @@ releases:
               pagerduty_configs:
                 - routing_key: '{{ env "KUBE_PROMETHEUS_ALERT_MANAGER_PAGERDUTY_INTEGRATION_KEY" }}'
                   send_resolved: true
+                  details:
+                    firing: '{{"{{"}} template "pagerduty.default.firing" . {{"}}"}}'
+                    resolved: '{{"{{"}} template "pagerduty.default.resolved" . {{"}}"}}'
 {{ end }}
           templates:
-            - ./*.tmpl
+            - ./deployment.tmpl
         service:
           type: "ClusterIP"
           port: "80"
@@ -143,6 +146,10 @@ releases:
           ### Optional: KUBE_PROMETHEUS_IMAGE_TAG; e.g. v2.2.1
           tag: '{{ env "KUBE_PROMETHEUS_IMAGE_TAG" | default "v2.2.1" }}'
           pullPolicy: "IfNotPresent"
+        ruleNamespaceSelector:
+          any: true
+        serviceMonitorNamespaceSelector:
+          any: true
         resources:
           limits:
             cpu: "400m"
@@ -233,22 +240,6 @@ releases:
         endpoints:
           - port: "metrics"
             interavl: 15s
-  - prometheusRules:
-      nginx-ingress:
-        labels:
-          prometheus: kube-prometheus
-        groups:
-        - name: pageduty.rules
-          rules:
-          - alert: PagerDutyTestError
-            annotations:
-              description: Pager Duty Test Error
-              summary: PagerDutyTestError
-            expr: nginx_ingress_controller_requests > 0
-            labels:
-              severity: warning
-
-
 
 #######################################################################################
 ## kube-prometheus-grafana                                                           ##

--- a/helmfile.d/0400.kube-prometheus.yaml
+++ b/helmfile.d/0400.kube-prometheus.yaml
@@ -96,20 +96,27 @@ releases:
             group_wait: "30s"
             group_interval: "5m"
             repeat_interval: "12h"
-            receiver: "slack_general"
+            receiver: "general"
             routes:
             - match:
                 alertname: "DeadMansSwitch"
               receiver: "null"
           receivers:
             - name: "null"
-            - name: "slack_general"
+            - name: "general"
+{{ if not ( env "KUBE_PROMETHEUS_ALERT_MANAGER_SLACK_WEBHOOK_URL" | empty ) }}
               slack_configs:
                   ### Required: KUBE_PROMETHEUS_ALERT_MANAGER_SLACK_WEBHOOK_URL
                 - api_url: '{{ env "KUBE_PROMETHEUS_ALERT_MANAGER_SLACK_WEBHOOK_URL" }}'
                   ### Required: KUBE_PROMETHEUS_ALERT_MANAGER_SLACK_CHANNEL; e.g. #alerts-staging
                   channel: '{{ env "KUBE_PROMETHEUS_ALERT_MANAGER_SLACK_CHANNEL" }}'
                   send_resolved: true
+{{ end }}
+{{ if not ( env "KUBE_PROMETHEUS_ALERT_MANAGER_PAGERDUTY_INTEGRATION_KEY" | empty ) }}
+              pagerduty_configs:
+                - routing_key: '{{ env "KUBE_PROMETHEUS_ALERT_MANAGER_PAGERDUTY_INTEGRATION_KEY" }}'
+                  send_resolved: true
+{{ end }}
           templates:
             - ./*.tmpl
         service:
@@ -226,6 +233,21 @@ releases:
         endpoints:
           - port: "metrics"
             interavl: 15s
+  - prometheusRules:
+      nginx-ingress:
+        labels:
+          prometheus: kube-prometheus
+        groups:
+        - name: pageduty.rules
+          rules:
+          - alert: PagerDutyTestError
+            annotations:
+              description: Pager Duty Test Error
+              summary: PagerDutyTestError
+            expr: nginx_ingress_controller_requests > 0
+            labels:
+              severity: warning
+
 
 
 #######################################################################################

--- a/helmfile.d/0400.kube-prometheus.yaml
+++ b/helmfile.d/0400.kube-prometheus.yaml
@@ -121,7 +121,7 @@ releases:
                     resolved: '{{"{{"}} template "pagerduty.default.resolved" . {{"}}"}}'
 {{ end }}
           templates:
-            - ./deployment.tmpl
+            - ./*.tmpl
         service:
           type: "ClusterIP"
           port: "80"

--- a/helmfile.d/values/kube-prometheus.alerts.template
+++ b/helmfile.d/values/kube-prometheus.alerts.template
@@ -5,6 +5,16 @@
 {{ define "__description" }}{{ end }}
 
 
+{{ define "__text_alert_common" }}
+*{{ (index .Alerts 0).Labels.severity | title }}:* {{ .CommonAnnotations.description }}
+
+*Source:* {{ (index .Alerts 0).GeneratorURL }}
+
+*Common Labels:*{{ range .CommonLabels.SortedPairs }}
+    • {{ .Name }}: `{{ .Value }}`{{ end }}
+{{ end }}
+
+
 {{ define "slack.default.title" }}{{ template "__subject" . }}{{ end }}
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "slack.default.fallback" }}{{ template "slack.default.title" . }} | {{ template "slack.default.titlelink" . }}{{ end }}
@@ -37,3 +47,45 @@
 {{ end }}
 
 {{ define "slack.default.footer" }}{{ end }}
+
+
+{{ define "pagerduty.default.description" }}{{ template "__subject" . }}{{ end }}
+{{ define "pagerduty.default.client" }}{{ template "__alertmanager" . }}{{ end }}
+{{ define "pagerduty.default.clientURL" }}{{ template "__alertmanagerURL" . }}{{ end }}
+
+{{ define "pagerduty.default.firing" }}
+{{- if eq ( .Alerts.Firing | len ) 0}}
+None
+{{- else }}
+{{ template "__text_alert_common" . }}
+*Alerts:*
+--------
+{{- $root :=  . }}
+{{- range .Alerts.Firing }}
+    *Additional Labels:* {{ range ( .Labels.Remove $root.CommonLabels.Names ).SortedPairs }}
+        • {{ .Name }}: `{{ .Value }}`{{ else }}`None`{{ end }}
+    *Additional Annotations:* {{ range ( .Annotations.Remove $root.CommonAnnotations.Names ).SortedPairs }}
+        • {{ .Name }}: `{{ .Value }}`{{ else }}`None`{{ end }}
+--------
+{{- end }}
+{{- end }}
+{{ end }}
+
+
+{{ define "pagerduty.default.resolved" }}
+{{- if eq ( .Alerts.Resolved | len ) 0}}
+None
+{{- else }}
+{{ template "__text_alert_common" . }}
+*Alerts:*
+--------
+{{- $root :=  . }}
+{{- range .Alerts.Resolved }}
+    *Additional Labels:* {{ range ( .Labels.Remove $root.CommonLabels.Names ).SortedPairs }}
+        • {{ .Name }}: `{{ .Value }}`{{ else }}`None`{{ end }}
+    *Additional Annotations:* {{ range ( .Annotations.Remove $root.CommonAnnotations.Names ).SortedPairs }}
+        • {{ .Name }}: `{{ .Value }}`{{ else }}`None`{{ end }}
+--------
+{{- end }}
+{{- end }}
+{{ end }}


### PR DESCRIPTION
## What
* Added `pagerduty` integration with `kube-prometheus` alerts
* Update `prometheus operator` to `0.23.2`
* Enable scrapping from `ServiceMonitors` in any namespaces

## Why
* To use `pagerduty` escalations
* To fix https://github.com/coreos/prometheus-operator/pull/1619
* Allow microservice apps to define own service monitors