### PR TITLE
Fix grafana and elasticsearch-logs

### DIFF
--- a/helmfile.d/0410.grafana.yaml
+++ b/helmfile.d/0410.grafana.yaml
@@ -22,8 +22,6 @@ releases:
   version: "1.14.0"
   wait: true
   values:
-    ### Optional: GRAFANA_EXTERNAL_VALUES_FILE;
-    - '{{ env "GRAFANA_EXTERNAL_VALUES_FILE" | default "values/grafana.dashboards.yaml" }}'
     - rbac:
         ### Optional: RBAC_ENABLED;
         create: {{ env "RBAC_ENABLED" | default "false" }}
@@ -84,7 +82,7 @@ releases:
           enabled: false
 
       plugins: '{{ env "GRAFANA_PLUGINS" }}'
-      
+
       # Sidecars that collect the configmaps with specified label and stores the included files them into the respective folders,
       # require at least Grafana 5 to work and can't be used together with parameters dashboardProviders, datasources and dashboards
       sidecar:

--- a/helmfile.d/0520.fluentd-elasticsearch-logs.yaml
+++ b/helmfile.d/0520.fluentd-elasticsearch-logs.yaml
@@ -49,5 +49,4 @@ releases:
       secret:
         FLUENT_ELASTICSEARCH_USER: '{{ env "ELASTICSEARCH_USER" | default "" }}'
         FLUENT_ELASTICSEARCH_PASSWORD: '{{ env "ELASTICSEARCH_PASSWORD" | default "" }}'
-    configDir: /fluentd/etc/
-  - values/fluentd-elasticsearch-logs-configs.yaml
+    configDir: /tmp/elasticsearch/


### PR DESCRIPTION
## what
* Fix `grafana` 
* Fix `fluentd-elasticsearch-logs`

## why
* `GRAFANA_EXTERNAL_VALUES_FILE` is not used and caused deployment to fail
* `/fluentd/etc/` is a read-only folder in k8s 10.8
* Functionality in `values/fluentd-elasticsearch-logs-configs.yaml` was already merged into https://github.com/fluent/fluentd-kubernetes-daemonset/pull/202. No separate file required

