### PR TITLE
[fluentd-elasticsearch-logs] Use debian based image

### DIFF
--- a/helmfile.d/0520.fluentd-elasticsearch-logs.yaml
+++ b/helmfile.d/0520.fluentd-elasticsearch-logs.yaml
@@ -29,7 +29,7 @@ releases:
   values:
   - image:
       repository: "fluent/fluentd-kubernetes-daemonset"
-      tag: '{{ env "ELASTICSEARCH_IMAGE_TAG" | default "v0.12.43-elasticsearch" }}'
+      tag: '{{ env "ELASTICSEARCH_IMAGE_TAG" | default "v0.12-debian-elasticsearch" }}'
       pullPolicy: "Always"
     resources:
       limits:


### PR DESCRIPTION
## What
* Use fluentd elastic search debian based version

## Why
* It is more stable then alpine