### PR TITLE
[codefresh] Add release for codefresh enterprise

### DIFF
--- a/releases/codefresh.yaml
+++ b/releases/codefresh.yaml
@@ -21,7 +21,8 @@ releases:
     namespace: "codefresh"
     vendor: "codefresh"
     default: "false"
-  chart: "codefresh/codefresh"
+  #chart: "codefresh/codefresh"
+  chart: "./../../onprem/codefresh"
   version: "0.6.99"
   wait: true
   values:
@@ -32,6 +33,12 @@ releases:
       appProtocol: https
       ### Codefresh App domain name
       appUrl: {{ env "CODEFRESH_HOST" }}
+      postgresDatabase: {{ env "AURORA_POSTGRES_DATABASE_NAME" }}
+      postgresPassword: {{ env "AURORA_POSTGRES_MASTER_PASSWORD" }}
+      postgresHostname: {{ env "AURORA_POSTGRES_MASTER_HOSTNAME" }}
+      postgresUser: {{ env "AURORA_POSTGRES_MASTER_USERNAME" }}
+      redisUrl: {{ env "REDIS_HOST" }}
+      redisPassword: {{ env "REDIS_AUTH_TOKEN" }}
 
     ### MTU Value for dockerd in builder and runner
     #  mtu: 1400
@@ -50,17 +57,16 @@ releases:
       kubernetes.io/ingress.class: {{ env "CODEFRESH_INGRESS_CLASS" | default "nginx" }}
       external-dns: enabled
       external-dns.alpha.kubernetes.io/hostname: {{ env "CODEFRESH_HOST" }}
-
-{{- if eq (env "CODEFRESH_INGRESS_CLASS" | default "nginx") "nginx" }}
+{{ if eq (env "CODEFRESH_INGRESS_CLASS" | default "nginx") "nginx" }}
       kubernetes.io/tls-acme: "true"
-      external-dns.alpha.kubernetes.io/target: '{{ env "NGINX_INGRESS_HOSTNAME" }}
+      external-dns.alpha.kubernetes.io/target: '{{ env "NGINX_INGRESS_HOSTNAME" }}'
       nginx.ingress.kubernetes.io/ssl-redirect: 'true'
       nginx.org/redirect-to-https: 'true'
-{{- else if eq (env "CODEFRESH_INGRESS_CLASS" | default "nginx") "alb" }}
+{{ else if eq (env "CODEFRESH_INGRESS_CLASS" | default "nginx") "alb" }}
       alb.ingress.kubernetes.io/scheme: internet-facing
       alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80},{"HTTPS":443}]'
       alb.ingress.kubernetes.io/certificate-arn: {{ env "CODEFRESH_INGRESS_ACM_ARN" }}
-{{- end }}
+{{ end }}
 
     ### Firebase secret
     firebaseSecret: {{ env "CODEFRESH_FIREBASE_SECRET" }}
@@ -98,6 +104,7 @@ releases:
     #    services: consul-postgresql
 
     postgresql:
+      enabled: false
       persistence:
         enabled: true
       nodeSelector: {}
@@ -117,6 +124,7 @@ releases:
     #    provisioner: local-volume
 
     redis:
+      enabled: false
       persistence:
         enabled: true
       nodeSelector: {}

--- a/releases/codefresh.yaml
+++ b/releases/codefresh.yaml
@@ -72,7 +72,7 @@ releases:
       enabled: false
       ### Codefresh App domain name
       domain: {{ env "CODEFRESH_HOST" }}
-      ### Uncomment if kubernetes cluster is RBAC enabled
+      ### Set RBAC_ENABLED to true if kubernetes cluster is RBAC enabled
       rbacEnable: {{ env "RBAC_ENABLED" | default "false" }}
 
     ### For github provider (the apiHost and loginHost are different)

--- a/releases/codefresh.yaml
+++ b/releases/codefresh.yaml
@@ -39,6 +39,7 @@ releases:
       postgresUser: {{ env "AURORA_POSTGRES_MASTER_USERNAME" }}
       redisUrl: {{ env "REDIS_HOST" }}
       redisPassword: {{ env "REDIS_AUTH_TOKEN" }}
+      rabbitmqHostname: {{ env "" }}
 
     ### MTU Value for dockerd in builder and runner
     #  mtu: 1400
@@ -93,22 +94,14 @@ releases:
       serviceType: NodePort
 {{- end }}
 
-    #  gitlab:
-    #    apiHost: gitlab-internal.codefresh.io
-    #    loginHost: gitlab-internal.codefresh.io
-    #    protocol: https
-
     consul:
-      ### Use NodeSelector to assing pod to a node
-      nodeSelector: {}
-    #    services: consul-postgresql
+      Storage: '{{ env "CODEFRESH_CONSUL_STORAGE_SIZE" | default "1Gi" }}'
+      StorageClass: '{{ env "CODEFRESH_CONSUL_STORAGE_CLASS" | default "default" }}'
 
     postgresql:
       enabled: false
       persistence:
         enabled: true
-      nodeSelector: {}
-    #    services: consul-postgresql
 
     mongodb:
       ## Provision new volume claim
@@ -177,8 +170,9 @@ releases:
           enabled: true
 
     cronus:
-      nodeSelector: {}
-    #    services: rabbitmq-registry
+      store:
+        size: '{{ env "CODEFRESH_CRONUS_STORAGE_SIZE" | default "1Gi" }}'
+      storageClass: '{{ env "CODEFRESH_CRONUS_STORAGE_CLASS" }}'
 
     builder:
       ## Use existing volume claim name

--- a/releases/codefresh.yaml
+++ b/releases/codefresh.yaml
@@ -2,6 +2,9 @@ repositories:
 # Codefresh on-prem repository
 - name: "codefresh"
   url: 'http://charts.codefresh.io/{{ env "CHANNEL" | default "dev" }}'
+# Incubator repo of official helm charts
+- name: "incubator"
+  url: "https://kubernetes-charts-incubator.storage.googleapis.com/"
 
 releases:
 
@@ -21,9 +24,8 @@ releases:
     namespace: "codefresh"
     vendor: "codefresh"
     default: "false"
-  #chart: "codefresh/codefresh"
-  chart: "./../../onprem/codefresh"
-  version: "0.6.99"
+  chart: "codefresh/codefresh"
+  version: "0.7.3"
   wait: true
   values:
   - global:
@@ -33,25 +35,16 @@ releases:
       appProtocol: https
       ### Codefresh App domain name
       appUrl: {{ env "CODEFRESH_HOST" }}
+{{- if eq (env "CODEFRESH_SELF_HOSTED_POSTGRESQL_ENABLED" | default "true") "false" }}
       postgresDatabase: {{ env "AURORA_POSTGRES_DATABASE_NAME" }}
       postgresPassword: {{ env "AURORA_POSTGRES_MASTER_PASSWORD" }}
       postgresHostname: {{ env "AURORA_POSTGRES_MASTER_HOSTNAME" }}
       postgresUser: {{ env "AURORA_POSTGRES_MASTER_USERNAME" }}
+{{- end }}
+{{- if eq (env "CODEFRESH_SELF_HOSTED_REDIS_ENABLED" | default "true") "false" }}
       redisUrl: {{ env "REDIS_HOST" }}
       redisPassword: {{ env "REDIS_AUTH_TOKEN" }}
-      rabbitmqHostname: {{ env "" }}
-
-    ### MTU Value for dockerd in builder and runner
-    #  mtu: 1400
-
-    ### Environment variables applied to all pods
-    #  env:
-    #    HTTP_PROXY: "http://myproxy.domain.com:8080"
-    #    http_proxy: "http://myproxy.domain.com:8080"
-    #    HTTPS_PROXY: "http://myproxy.domain.com:8080"
-    #    https_proxy: "http://myproxy.domain.com:8080"
-    #    NO_PROXY: "127.0.0.1,localhost,kubernetes.default.svc,.codefresh.svc,100.64.0.1,169.254.169.254,cf-builder,cf-cfapi,cf-cfui,cf-chartmuseum,cf-charts-manager,cf-cluster-providers,cf-consul,cf-consul-ui,cf-context-manager,cf-cronus,cf-helm-repo-manager,cf-hermes,cf-ingress-controller,cf-ingress-http-backend,cf-kube-integration,cf-mongodb,cf-nats,cf-nomios,cf-pipeline-manager,cf-postgresql,cf-rabbitmq,cf-redis,cf-registry,cf-runner,cf-runtime-environment-manager,cf-store"
-    #    no_proxy: "127.0.0.1,localhost,kubernetes.default.svc,.codefresh.svc,100.64.0.1,169.254.169.254,cf-builder,cf-cfapi,cf-cfui,cf-chartmuseum,cf-charts-manager,cf-cluster-providers,cf-consul,cf-consul-ui,cf-context-manager,cf-cronus,cf-helm-repo-manager,cf-hermes,cf-ingress-controller,cf-ingress-http-backend,cf-kube-integration,cf-mongodb,cf-nats,cf-nomios,cf-pipeline-manager,cf-postgresql,cf-rabbitmq,cf-redis,cf-registry,cf-runner,cf-runtime-environment-manager,cf-store"
+{{- end }}
 
     ## Custom annotations for Codefresh ingress resource that override defaults
     annotations:
@@ -99,7 +92,7 @@ releases:
       StorageClass: '{{ env "CODEFRESH_CONSUL_STORAGE_CLASS" | default "default" }}'
 
     postgresql:
-      enabled: false
+      enabled: {{ env "CODEFRESH_SELF_HOSTED_POSTGRESQL_ENABLED" | default "true" }}
       persistence:
         enabled: true
 
@@ -113,21 +106,14 @@ releases:
         accessMode: ReadWriteOnce
         size: 8Gi
 
-      nodeSelector: {}
-    #    provisioner: local-volume
-
     redis:
-      enabled: false
+      enabled: {{ env "CODEFRESH_SELF_HOSTED_REDIS_ENABLED" | default "true" }}
       persistence:
         enabled: true
-      nodeSelector: {}
-    #    provisioner: local-volume
 
     rabbitmq:
       persistence:
         enabled: true
-      nodeSelector: {}
-    #    services: rabbitmq-registry
 
     registry:
       nodeSelector: {}
@@ -172,7 +158,7 @@ releases:
     cronus:
       store:
         size: '{{ env "CODEFRESH_CRONUS_STORAGE_SIZE" | default "1Gi" }}'
-      storageClass: '{{ env "CODEFRESH_CRONUS_STORAGE_CLASS" }}'
+      storageClass: '{{ env "CODEFRESH_CRONUS_STORAGE_CLASS" | default "default"}}'
 
     builder:
       ## Use existing volume claim name
@@ -227,3 +213,51 @@ releases:
         auths:
           gcr.io:
             auth: {{ cat "_json_key:" ( env "CODEFRESH_SA") | b64enc }}
+
+- name: "cf-ext"
+  namespace: "codefresh"
+  labels:
+    chart: "raw"
+    component: "codefresh"
+    namespace: "codefresh"
+    vendor: "kubernetes-incubator"
+    default: "false"
+  chart: "incubator/raw"
+  version: "0.1.0"
+  wait: true
+  values:
+  - resources:
+    - apiVersion: extensions/v1beta1
+      kind: Ingress
+      metadata:
+        namespace: codefresh
+        name: cf-extended
+      annotations:
+        kubernetes.io/ingress.class: nginx
+        nginx.ingress.kubernetes.io/configuration-snippet: |
+          more_set_headers "X-Request-ID: $request_id";
+          proxy_set_header X-Request-ID $request_id;
+        nginx.ingress.kubernetes.io/service-upstream: "true"
+        nginx.ingress.kubernetes.io/ssl-redirect: "true"
+        nginx.org/redirect-to-https: "true"
+      spec:
+        rules:
+        - host: {{ env "CODEFRESH_HOST" }}
+          http:
+            paths:
+              - path: /
+              backend:
+              serviceName: cf-cfui
+              servicePort: 80
+            - path: /api/
+              backend:
+                serviceName: cf-cfapi
+                servicePort: 80
+            - path: /nomios/
+              backend:
+                serviceName: cf-nomios
+                servicePort: 80
+        tls:
+        - hosts:
+          - {{ env "CODEFRESH_HOST" }}
+          secretName: cf-codefresh-star-selfsigned

--- a/releases/codefresh.yaml
+++ b/releases/codefresh.yaml
@@ -27,8 +27,8 @@ releases:
   values:
   - global:
       ### Instantiate databases with seed data. Usually used in dynamic and on-prem environments.
-      #seedJobs: true
-      #certsJobs: true
+      seedJobs: {{ env "CODEFRESH_SEED_JOBS_ENABLED" | default "false" }}
+      certsJobs: {{ env "CODEFRESH_SEED_JOBS_ENABLED" | default "false" }}
 
       #### Depending on git provider use matching values
       ### for Gitlab git provider

--- a/releases/codefresh.yaml
+++ b/releases/codefresh.yaml
@@ -1,0 +1,226 @@
+repositories:
+# Codefresh on-prem repository
+- name: "codefresh"
+  url: 'http://charts.codefresh.io/{{ env "CHANNEL" | default "dev" }}'
+
+releases:
+
+#######################################################################################
+## Codefresh On-Prem                                                                 ##
+#######################################################################################
+
+#
+# References:
+#   - https://github.com/codefresh-io/onprem
+#
+- name: "cf"
+  namespace: "codefresh"
+  labels:
+    chart: "codefresh"
+    component: "codefresh"
+    namespace: "codefresh"
+    vendor: "codefresh"
+    default: "false"
+  chart: "codefresh/codefresh"
+  version: "0.6.99"
+  wait: true
+  values:
+  - global:
+      ### Instantiate databases with seed data. Usually used in dynamic and on-prem environments.
+      #seedJobs: true
+      #certsJobs: true
+
+      #### Depending on git provider use matching values
+      ### for Gitlab git provider
+      #  gitlabClientID:
+      #  gitlabClientSecret:
+      ### for Bitbucket git provider
+      #  bitbucketClientID:
+      #  bitbucketClientSecret:
+      ### for Github git provider
+      #  githubClientID:
+      #  githubClientSecret:
+      #  githubInternalToken:
+      appProtocol: https
+      ### Codefresh App domain name
+      appUrl: {{ env "CODEFRESH_HOST" }}
+
+    ### MTU Value for dockerd in builder and runner
+    #  mtu: 1400
+
+    ### Environment variables applied to all pods
+    #  env:
+    #    HTTP_PROXY: "http://myproxy.domain.com:8080"
+    #    http_proxy: "http://myproxy.domain.com:8080"
+    #    HTTPS_PROXY: "http://myproxy.domain.com:8080"
+    #    https_proxy: "http://myproxy.domain.com:8080"
+    #    NO_PROXY: "127.0.0.1,localhost,kubernetes.default.svc,.codefresh.svc,100.64.0.1,169.254.169.254,cf-builder,cf-cfapi,cf-cfui,cf-chartmuseum,cf-charts-manager,cf-cluster-providers,cf-consul,cf-consul-ui,cf-context-manager,cf-cronus,cf-helm-repo-manager,cf-hermes,cf-ingress-controller,cf-ingress-http-backend,cf-kube-integration,cf-mongodb,cf-nats,cf-nomios,cf-pipeline-manager,cf-postgresql,cf-rabbitmq,cf-redis,cf-registry,cf-runner,cf-runtime-environment-manager,cf-store"
+    #    no_proxy: "127.0.0.1,localhost,kubernetes.default.svc,.codefresh.svc,100.64.0.1,169.254.169.254,cf-builder,cf-cfapi,cf-cfui,cf-chartmuseum,cf-charts-manager,cf-cluster-providers,cf-consul,cf-consul-ui,cf-context-manager,cf-cronus,cf-helm-repo-manager,cf-hermes,cf-ingress-controller,cf-ingress-http-backend,cf-kube-integration,cf-mongodb,cf-nats,cf-nomios,cf-pipeline-manager,cf-postgresql,cf-rabbitmq,cf-redis,cf-registry,cf-runner,cf-runtime-environment-manager,cf-store"
+
+    ## Custom annotations for Codefresh ingress resource that override defaults
+    annotations:
+      kubernetes.io/ingress.class: nginx
+      kubernetes.io/tls-acme: "false"
+      external-dns: enabled
+      external-dns.alpha.kubernetes.io/target: {{ env "NGINX_INGRESS_HOSTNAME" }}
+      external-dns.alpha.kubernetes.io/hostname: {{ env "CODEFRESH_HOST" }}
+      nginx.ingress.kubernetes.io/ssl-redirect: 'true'
+      nginx.org/redirect-to-https: 'true'
+
+    ### Firebase secret
+    firebaseSecret: {{ env "CODEFRESH_FIREBASE_SECRET" }}
+
+    ### Uncomment if kubernetes cluster is RBAC enabled
+    rbacEnable: {{ env "RBAC_ENABLED" | default "false" }}
+
+    ingress:
+      enabled: false
+      ### Codefresh App domain name
+      domain: {{ env "CODEFRESH_HOST" }}
+      ### Uncomment if kubernetes cluster is RBAC enabled
+      rbacEnable: {{ env "RBAC_ENABLED" | default "false" }}
+
+    ### For github provider (the apiHost and loginHost are different)
+    cfapi:
+      rbacEnable: {{ env "RBAC_ENABLED" | default "false" }}
+      redeploy: true
+      github:
+        apiHost: api.github.com
+        loginHost: github.com
+        protocol: https
+
+    #  gitlab:
+    #    apiHost: gitlab-internal.codefresh.io
+    #    loginHost: gitlab-internal.codefresh.io
+    #    protocol: https
+
+    consul:
+      ### Use NodeSelector to assing pod to a node
+      nodeSelector: {}
+    #    services: consul-postgresql
+
+    postgresql:
+      persistence:
+        enabled: true
+      nodeSelector: {}
+    #    services: consul-postgresql
+
+    mongodb:
+      ## Provision new volume claim
+      persistence:
+        enabled: true
+        ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
+        ## Default: volume.alpha.kubernetes.io/storage-class: default
+        ##
+        accessMode: ReadWriteOnce
+        size: 8Gi
+
+      nodeSelector: {}
+    #    provisioner: local-volume
+
+    redis:
+      persistence:
+        enabled: true
+      nodeSelector: {}
+    #    provisioner: local-volume
+
+    rabbitmq:
+      persistence:
+        enabled: true
+      nodeSelector: {}
+    #    services: rabbitmq-registry
+
+    registry:
+      nodeSelector: {}
+        #    services: rabbitmq-registry
+        ## Uncomment if needed to apply custom configuration to registry
+        #registryConfig:
+        ## Insert custom registry configuration (https://docs.docker.com/registry/configuration/)
+        #version: 0.1
+        #log:
+        #level: debug
+        #fields:
+        #service: registry
+        #storage:
+        #cache:
+        #blobdescriptor: inmemory
+        #s3:
+        #region: YOUR_REGION
+        #bucket: YOUR_BUCKET_NAME
+        #accesskey: AWS_ACCESS_KEY
+        #secretkey: AWS_SECRET_KEY
+        #http:
+        #addr: :5000
+        #headers:
+        #X-Content-Type-Options: [nosniff]
+        #health:
+        #storagedriver:
+        #enabled: true
+      #interval: 10s
+      #threshold: 3
+
+    hermes:
+      nodeSelector: {}
+      #    services: rabbitmq-registry
+      redis:
+        ## Set hermes store password. It is mandatory
+        redisPassword: verysecurepassword
+        nodeSelector: {}
+        #      services: rabbitmq-registry
+        persistence:
+          enabled: true
+
+    cronus:
+      nodeSelector: {}
+    #    services: rabbitmq-registry
+
+    builder:
+      ## Use existing volume claim name
+      #pvcName: cf-builder
+      ## Set time to run docker cleaner
+      dockerCleanerCron: 0 0 * * *
+      ## Override builder PV initial size
+      varLibDockerVolume:
+        storageSize: 100Gi
+
+    runner:
+      ## Set time to run docker cleaner
+      dockerCleanerCron: 0 0 * * *
+      ## Override runner PV initial size
+      varLibDockerVolume:
+        storageSize: 100Gi
+
+    backups:
+      #enabled: true
+      awsAccessKey:
+      awsSecretAccessKey:
+      s3Url: s3://<some-bucket>
+
+    dockerconfigjson:
+      auths:
+        gcr.io:
+          auth: {{ cat "_json_key:" ( env "CODEFRESH_SA") | b64enc }}
+
+    cfui:
+      dockerconfigjson:
+        auths:
+          gcr.io:
+            auth: {{ cat "_json_key:" ( env "CODEFRESH_SA") | b64enc }}
+
+    runtime-environment-manager:
+      dockerconfigjson:
+        auths:
+          gcr.io:
+            auth: {{ cat "_json_key:" ( env "CODEFRESH_SA") | b64enc }}
+
+    onboarding-status:
+      dockerconfigjson:
+        auths:
+          gcr.io:
+            auth: {{ cat "_json_key:" ( env "CODEFRESH_SA") | b64enc }}
+
+    cfanalytic:
+      dockerconfigjson:
+        auths:
+          gcr.io:
+            auth: {{ cat "_json_key:" ( env "CODEFRESH_SA") | b64enc }}

--- a/releases/codefresh.yaml
+++ b/releases/codefresh.yaml
@@ -29,18 +29,6 @@ releases:
       ### Instantiate databases with seed data. Usually used in dynamic and on-prem environments.
       seedJobs: {{ env "CODEFRESH_SEED_JOBS_ENABLED" | default "false" }}
       certsJobs: {{ env "CODEFRESH_SEED_JOBS_ENABLED" | default "false" }}
-
-      #### Depending on git provider use matching values
-      ### for Gitlab git provider
-      #  gitlabClientID:
-      #  gitlabClientSecret:
-      ### for Bitbucket git provider
-      #  bitbucketClientID:
-      #  bitbucketClientSecret:
-      ### for Github git provider
-      #  githubClientID:
-      #  githubClientSecret:
-      #  githubInternalToken:
       appProtocol: https
       ### Codefresh App domain name
       appUrl: {{ env "CODEFRESH_HOST" }}
@@ -59,13 +47,20 @@ releases:
 
     ## Custom annotations for Codefresh ingress resource that override defaults
     annotations:
-      kubernetes.io/ingress.class: nginx
-      kubernetes.io/tls-acme: "false"
+      kubernetes.io/ingress.class: {{ env "CODEFRESH_INGRESS_CLASS" | default "nginx" }}
       external-dns: enabled
-      external-dns.alpha.kubernetes.io/target: {{ env "NGINX_INGRESS_HOSTNAME" }}
       external-dns.alpha.kubernetes.io/hostname: {{ env "CODEFRESH_HOST" }}
+
+{{- if eq (env "CODEFRESH_INGRESS_CLASS" | default "nginx") "nginx" }}
+      kubernetes.io/tls-acme: "true"
+      external-dns.alpha.kubernetes.io/target: '{{ env "NGINX_INGRESS_HOSTNAME" }}
       nginx.ingress.kubernetes.io/ssl-redirect: 'true'
       nginx.org/redirect-to-https: 'true'
+{{- else if eq (env "CODEFRESH_INGRESS_CLASS" | default "nginx") "alb" }}
+      alb.ingress.kubernetes.io/scheme: internet-facing
+      alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80},{"HTTPS":443}]'
+      alb.ingress.kubernetes.io/certificate-arn: {{ env "CODEFRESH_INGRESS_ACM_ARN" }}
+{{- end }}
 
     ### Firebase secret
     firebaseSecret: {{ env "CODEFRESH_FIREBASE_SECRET" }}
@@ -88,6 +83,9 @@ releases:
         apiHost: api.github.com
         loginHost: github.com
         protocol: https
+{{- if eq (env "CODEFRESH_INGRESS_CLASS" | default "nginx") "alb" }}
+      serviceType: NodePort
+{{- end }}
 
     #  gitlab:
     #    apiHost: gitlab-internal.codefresh.io
@@ -202,6 +200,9 @@ releases:
           auth: {{ cat "_json_key:" ( env "CODEFRESH_SA") | b64enc }}
 
     cfui:
+{{- if eq (env "CODEFRESH_INGRESS_CLASS" | default "nginx") "alb" }}
+      serviceType: NodePort
+{{- end }}
       dockerconfigjson:
         auths:
           gcr.io:

--- a/releases/codefresh.yaml
+++ b/releases/codefresh.yaml
@@ -25,7 +25,7 @@ releases:
     vendor: "codefresh"
     default: "false"
   chart: "codefresh/codefresh"
-  version: "0.7.3"
+  version: "0.7.9"
   wait: true
   values:
   - global:
@@ -183,6 +183,7 @@ releases:
           auth: {{ cat "_json_key:" ( env "CODEFRESH_SA") | b64enc }}
 
     cfui:
+      imageTag: 2.8.107
 {{- if eq (env "CODEFRESH_INGRESS_CLASS" | default "nginx") "alb" }}
       serviceType: NodePort
 {{- end }}
@@ -240,7 +241,7 @@ releases:
         - host: {{ env "CODEFRESH_HOST" }}
           http:
             paths:
-              - path: /
+            - path: /
               backend:
               serviceName: cf-cfui
               servicePort: 80

--- a/releases/codefresh.yaml
+++ b/releases/codefresh.yaml
@@ -154,7 +154,7 @@ releases:
       #    services: rabbitmq-registry
       redis:
         ## Set hermes store password. It is mandatory
-        redisPassword: verysecurepassword
+        redisPassword: '{{ env "CODEFRESH_HERMES_REDIS_PASSWORD" | default "verysecurepassword" }}'
         nodeSelector: {}
         #      services: rabbitmq-registry
         persistence:
@@ -185,9 +185,9 @@ releases:
 
     backups:
       #enabled: true
-      awsAccessKey:
-      awsSecretAccessKey:
-      s3Url: s3://<some-bucket>
+      awsAccessKey: '{{ env "CODEFRESH_BACKUPS_AWS_ACCESS_KEY" }}'
+      awsSecretAccessKey: '{{ env "CODEFRESH_BACKUPS_AWS_ACCESS_SECRET" }}'
+      s3Url: s3://'{{ env "CODEFRESH_BACKUPS_BUCKET_NAME" }}'
 
     dockerconfigjson:
       auths:

--- a/releases/codefresh.yaml
+++ b/releases/codefresh.yaml
@@ -116,33 +116,28 @@ releases:
         enabled: true
 
     registry:
-      nodeSelector: {}
-        #    services: rabbitmq-registry
-        ## Uncomment if needed to apply custom configuration to registry
-        #registryConfig:
-        ## Insert custom registry configuration (https://docs.docker.com/registry/configuration/)
-        #version: 0.1
-        #log:
-        #level: debug
-        #fields:
-        #service: registry
-        #storage:
-        #cache:
-        #blobdescriptor: inmemory
-        #s3:
-        #region: YOUR_REGION
-        #bucket: YOUR_BUCKET_NAME
-        #accesskey: AWS_ACCESS_KEY
-        #secretkey: AWS_SECRET_KEY
-        #http:
-        #addr: :5000
-        #headers:
-        #X-Content-Type-Options: [nosniff]
-        #health:
-        #storagedriver:
-        #enabled: true
-      #interval: 10s
-      #threshold: 3
+      registryConfig:
+      # Insert custom registry configuration (https://docs.docker.com/registry/configuration/)
+#        version: 0.1
+#        log:
+#          level: debug
+#        fields:
+#          service: registry
+#        storage:
+#          cache:
+#            blobdescriptor: inmemory
+#          s3:
+#            region: YOUR_REGION
+#            bucket: YOUR_BUCKET_NAME
+#            accesskey: AWS_ACCESS_KEY
+#            secretkey: AWS_SECRET_KEY
+#        http:
+#          addr: :5000
+#        headers:
+#          X-Content-Type-Options: [nosniff]
+#        health:
+#        storagedriver:
+#          enabled: true
 
     hermes:
       nodeSelector: {}

--- a/releases/codefresh.yaml
+++ b/releases/codefresh.yaml
@@ -25,7 +25,7 @@ releases:
     vendor: "codefresh"
     default: "false"
   chart: "codefresh/codefresh"
-  version: "0.7.9"
+  version: "0.7.3"
   wait: true
   values:
   - global:
@@ -77,6 +77,7 @@ releases:
 
     ### For github provider (the apiHost and loginHost are different)
     cfapi:
+      replicaCount: {{ env "CODEFRESH_API_REPLICA_COUNT" | default "1" }}
       rbacEnable: {{ env "RBAC_ENABLED" | default "false" }}
       redeploy: true
       github:
@@ -87,6 +88,13 @@ releases:
       serviceType: NodePort
 {{- end }}
 
+    context-manager:
+      replicaCount: {{ env "CODEFRESH_CONTEXT_MANAGER_REPLICA_COUNT" | default "1" }}
+
+    pipeline-manager:
+      environment:
+        replicaCount: {{ env "CODEFRESH_PIPELINE_MANAGER_REPLICA_COUNT" | default "1" }}
+
     consul:
       Storage: '{{ env "CODEFRESH_CONSUL_STORAGE_SIZE" | default "1Gi" }}'
       StorageClass: '{{ env "CODEFRESH_CONSUL_STORAGE_CLASS" | default "default" }}'
@@ -94,7 +102,7 @@ releases:
     postgresql:
       enabled: {{ env "CODEFRESH_SELF_HOSTED_POSTGRESQL_ENABLED" | default "true" }}
       persistence:
-        enabled: true
+        enabled: {{ env "CODEFRESH_SELF_HOSTED_POSTGRESQL_ENABLED" | default "true" }}
 
     mongodb:
       ## Provision new volume claim
@@ -109,35 +117,37 @@ releases:
     redis:
       enabled: {{ env "CODEFRESH_SELF_HOSTED_REDIS_ENABLED" | default "true" }}
       persistence:
-        enabled: true
+        enabled: {{ env "CODEFRESH_SELF_HOSTED_REDIS_ENABLED" | default "true" }}
 
     rabbitmq:
       persistence:
         enabled: true
 
     registry:
+      pvcName: null
+      replicaCount: {{ env "CODEFRESH_REGISTRY_REPLICA_COUNT" | default "1" }}
       registryConfig:
-      # Insert custom registry configuration (https://docs.docker.com/registry/configuration/)
-#        version: 0.1
-#        log:
-#          level: debug
-#        fields:
-#          service: registry
-#        storage:
-#          cache:
-#            blobdescriptor: inmemory
-#          s3:
-#            region: YOUR_REGION
-#            bucket: YOUR_BUCKET_NAME
-#            accesskey: AWS_ACCESS_KEY
-#            secretkey: AWS_SECRET_KEY
-#        http:
-#          addr: :5000
-#        headers:
-#          X-Content-Type-Options: [nosniff]
-#        health:
-#        storagedriver:
-#          enabled: true
+        version: 0.1
+        log:
+          fields:
+            service: 'registry'
+        storage:
+          cache:
+            blobdescriptor: 'inmemory'
+          s3:
+            region: {{ env "CODEFRESH_SELF_HOSTER_REGISTRY_S3_REGION" | default "us-west-2" }}
+            bucket: {{ env "CODEFRESH_SELF_HOSTER_REGISTRY_S3_BUCKET_NAME" }}
+            accesskey: {{ env "AWS_ACCESS_KEY_ID" }}
+            secretkey: {{ env "AWS_SECRET_ACCESS_KEY" }}
+            rootdirectory: /
+        http:
+          addr: ':5000'
+          secret: {{ env "CODEFRESH_REGISTRY_SIGN_SECRET" | default uuidv4  }}
+        health:
+          storagedriver:
+            enabled: true
+            interval: 10s
+            threshold: 3
 
     hermes:
       nodeSelector: {}
@@ -156,6 +166,7 @@ releases:
       storageClass: '{{ env "CODEFRESH_CRONUS_STORAGE_CLASS" | default "default"}}'
 
     builder:
+      replicaCount: {{ env "CODEFRESH_BUILDER_REPLICA_COUNT" | default "1" }}
       ## Use existing volume claim name
       #pvcName: cf-builder
       ## Set time to run docker cleaner
@@ -165,6 +176,7 @@ releases:
         storageSize: 100Gi
 
     runner:
+      replicaCount: {{ env "CODEFRESH_RUNNER_REPLICA_COUNT" | default "1" }}
       ## Set time to run docker cleaner
       dockerCleanerCron: 0 0 * * *
       ## Override runner PV initial size
@@ -184,6 +196,7 @@ releases:
 
     cfui:
       imageTag: 2.8.107
+      replicaCount: {{ env "CODEFRESH_UI_REPLICA_COUNT" | default "1" }}
 {{- if eq (env "CODEFRESH_INGRESS_CLASS" | default "nginx") "alb" }}
       serviceType: NodePort
 {{- end }}
@@ -243,8 +256,8 @@ releases:
             paths:
             - path: /
               backend:
-              serviceName: cf-cfui
-              servicePort: 80
+                serviceName: cf-cfui
+                servicePort: 80
             - path: /api/
               backend:
                 serviceName: cf-cfapi

--- a/releases/kube-lego.yaml
+++ b/releases/kube-lego.yaml
@@ -51,5 +51,5 @@ releases:
         memory: "128Mi"
 
     rbac:
-      create: '{{ env "RBAC_ENABLED" | default "false" }}'
+      create: {{ env "RBAC_ENABLED" | default "false" }}
       serviceAccountName: default

--- a/releases/nginx-ingress.yaml
+++ b/releases/nginx-ingress.yaml
@@ -157,6 +157,7 @@ releases:
 #   - https://grafana.com/grafana
 #   - https://github.com/helm/charts/tree/master/stable/grafana
 #
+{{ if eq ( env "NGINX_INGRESS_METRICS_ENABLED" | default "false" ) "true" }}
 - name: "ingress-monitoring"
   namespace: "monitoring"
   labels:
@@ -164,7 +165,7 @@ releases:
     component: "monitoring"
     namespace: "monitoring"
     vendor: "cloudposse"
-    default: '{{ env "NGINX_INGRESS_METRICS_ENABLED" | default "false" }}'
+    default: {{ env "NGINX_INGRESS_METRICS_ENABLED" | default "false" }}
   chart: "cloudposse-incubator/monochart"
   version: "0.4.0"
   wait: true
@@ -208,3 +209,4 @@ releases:
   set:
   - name: "configMaps.dashboards.files.nginx\\.json"
     file: https://raw.githubusercontent.com/cloudposse/grafana-dashboards/{{ env "GRAFANA_DASHBOARDS_VERSION" | default "1.0" }}/nginx-ingress/nginx.json
+{{ end }}


### PR DESCRIPTION
## What
* Added Codefresh on-prem helmfile release

## Why
* To run self-hosted codefresh enterprise

## Prepare
* Get `firebase`, and `sa.json` from Codefresh 
* Run `cat sa.json | chamber write codefresh CODEFRESH_SA -` 
* Run `head -c -1 firebase | chamber write codefresh CODEFRESH_FIREBASE_SECRET -` 
* Run `chamber write codefresh CODEFRESH_HOST codefresh.example.com` 

## Install
* Run `export CODEFRESH_SEED_JOBS_ENABLED=true`
* Run `chamber exec kops codefresh terraform-aws-codefresh-backing-services -- helmfile -f codefresh.yaml sync`
* Run `export CODEFRESH_SEED_JOBS_ENABLED=false`

## Update
* Run `chamber exec kops codefresh  terraform-aws-codefresh-backing-services -- helmfile -f codefresh.yaml sync`
