### PR TITLE
ECS provisioner

### DIFF
--- a/releases/efs-provisioner.yaml
+++ b/releases/efs-provisioner.yaml
@@ -1,0 +1,66 @@
+repositories:
+# Stable repo of official helm charts
+- name: "stable"
+  url: "https://kubernetes-charts.storage.googleapis.com"
+
+releases:
+
+################################################################################
+## EFS provisioner #############################################################
+################################################################################
+
+#
+# References:
+#   - https://github.com/helm/charts/blob/master/stable/efs-provisioner/values.yaml
+#   - https://github.com/kubernetes-incubator/external-storage/tree/master/aws/efs
+#
+- name: "efs-provisioner"
+  namespace: "kube-system"
+  labels:
+    chart: "efs-provisioner"
+    repo: "stable"
+    component: "efs"
+    namespace: "kube-system"
+    vendor: "kubernetes"
+    default: "false"
+  chart: "stable/efs-provisioner"
+  version: "0.1.3"
+  wait: true
+  values:
+    - global:
+        deployEnv: '{{ env "DEPLOY_ENV" | default "dev" }}'
+      image:
+        repository: '{{ env "EFS_PROVISIONER_IMAGE_REPOSITORY" | default "quay.io/external_storage/efs-provisioner" }}'
+        tag: '{{ env "EFS_PROVISIONER_IMAGE_TAG" | default "v0.1.2" }}'
+        pullPolicy: "IfNotPresent"
+      resources:
+        limits:
+          cpu: '{{ env "EFS_LIMITS_CPU" | default "200m" }}'
+          memory: '{{ env "EFS_LIMITS_MEMORY" | default "128Mi" }}'
+        requests:
+          cpu: '{{ env "EFS_REQUESTS_CPU" | default "100m" }}'
+          memory: '{{ env "EFS_REQUESTS_MEMORY" | default "128Mi" }}'
+      rbac:
+        ### Optional: RBAC_ENABLED;
+        create: {{ env "RBAC_ENABLED" | default "false" }}
+      serviceAccount:
+        # Specifies whether a ServiceAccount should be created
+        create: {{ env "RBAC_ENABLED" | default "false" }}
+        # The name of the ServiceAccount to use.
+        # If not set and create is true, a name is generated using the fullname template
+        name: '{{ env "EFS_SERVICE_ACCOUNT_NAME" | default "" }}'
+      efsProvisioner:
+        efsFileSystemId: '{{ env "EFS_FILE_SYSTEM_ID" }}'
+        awsRegion: '{{ env "AWS_REGION" }}'
+        path: '{{ env "EFS_PV_PATH" }}'
+        provisionerName: '{{ env "EFS_PROVISIONER_NAME" | default "aws-efs" }}'
+        storageClass:
+          name: '{{ env "EFS_STORAGE_CLASS_NAME" | default "efs" }}'
+          isDefault: {{ env "EFS_STORAGE_CLASS_IS_DEFAULT" | default "false" }}
+          gidAllocate:
+            enabled: '{{ env "EFS_STORAGE_CLASS_GID_ALLOCATE_ENABLED" | default "true" }}'
+            gidMin: '{{ env "EFS_STORAGE_CLASS_GID_ALLOCATE_GIT_MIN" | default "40000" }}'
+            gidMax: '{{ env "EFS_STORAGE_CLASS_GID_ALLOCATE_GIT_MAX" | default "50000" }}'
+          reclaimPolicy: '{{ env "EFS_STORAGE_CLASS_RECLAIM_POLICY" | default "Delete" }}'
+      annotations:
+        iam.amazonaws.com/role: '{{ env "EFS_PROVISIONER_IAM_ROLE" }}'


### PR DESCRIPTION
## what

Helmfile for [efs-provisioner](https://github.com/kubernetes-incubator/external-storage/tree/master/aws/efs)

## why

so we can mount EFS inside kops clusters. This is a current requirement for the CodeFresh Enterprise backing services

## testing

I have successfully deployed this helmfile to testing.cloudposse.co and it is able to mount EFS into the k8s cluster