### PR TITLE
Fix `kube-lego` RBAC

### DIFF
--- a/releases/kube-lego.yaml
+++ b/releases/kube-lego.yaml
@@ -51,5 +51,5 @@ releases:
         memory: "128Mi"
 
     rbac:
-      create: '{{ env "RBAC_ENABLED" | default "false" }}'
+      create: {{ env "RBAC_ENABLED" | default "false" }}
       serviceAccountName: default


### PR DESCRIPTION
## what
* Fix `kube-lego` RBAC

## why
* Quoted boolean value was always evaluated to `true`
