### PR TITLE
[datadog] Changes to fixed configuration

### DIFF
--- a/releases/datadog.yaml
+++ b/releases/datadog.yaml
@@ -64,9 +64,6 @@ releases:
         image:
           ### Version of cluster agent from https://hub.docker.com/r/datadog/cluster-agent/tags
           tag: {{ env "DATADOG_CLUSTER_AGENT_IMAGE_TAG" | default "latest" }}
-        tolerations:
-          - key: node-role.kubernetes.io/master
-            effect: NoSchedule
       rbac:
         ### Optional: RBAC_ENABLED;
         create: {{ env "RBAC_ENABLED" | default "false" }}

--- a/releases/datadog.yaml
+++ b/releases/datadog.yaml
@@ -34,13 +34,6 @@ releases:
         ### Version of datadog agent from https://hub.docker.com/r/datadog/agent/tags/
         tag: '{{ env "DATADOG_IMAGE_TAG" | default "latest" }}'
         pullPolicy: "IfNotPresent"
-      resources:
-        limits:
-          cpu: "256m"
-          memory: "512Mi"
-        requests:
-          cpu: "50m"
-          memory: "64Mi"
       datadog:
         ### Required: DATADOG_API_KEY;
         apiKey: '{{ requiredEnv "DATADOG_API_KEY" }}'
@@ -58,12 +51,26 @@ releases:
 {{ if env "DATADOG_TAG_WITH_CLUSTER_NAME" | default "false" }}   
         tags: 'cluster:{{ requiredEnv "KOPS_CLUSTER_NAME" }}' 
 {{ end }}
+        resources:
+          limits:
+            cpu: "256m"
+            memory: "512Mi"
+          requests:
+            cpu: "50m"
+            memory: "128Mi"
       clusterAgent:
         enabled: {{ env "DATADOG_CLUSTER_AGENT_ENABLED" | default "false" }}
         repository: "datadog/cluster-agent"
         image:
           ### Version of cluster agent from https://hub.docker.com/r/datadog/cluster-agent/tags
           tag: {{ env "DATADOG_CLUSTER_AGENT_IMAGE_TAG" | default "latest" }}
+        resources:
+          limits:
+            cpu: "256m"
+            memory: "512Mi"
+          requests:
+            cpu: "50m"
+            memory: "32Mi"
       rbac:
         ### Optional: RBAC_ENABLED;
         create: {{ env "RBAC_ENABLED" | default "false" }}


### PR DESCRIPTION
## what
- Remove tolerations for cluster agent
- Correctly set resource requests
- Adjust resource requests based on observed behavior

## why
- Cluster agent only runs 1 (or 3) per cluster, not on each node, so it should not have tolerations
- Resource limits were of unknown origin and were specified in the wrong place, leading them to be ignored and defaults applied. New resource limits are based on observed behavior of agents as well as taking defaults into account as recommendations.