### PR TITLE
[teleport-ent] Shorten kubernetes names for teleport

### DIFF
--- a/releases/teleport-ent-auth.yaml
+++ b/releases/teleport-ent-auth.yaml
@@ -41,7 +41,9 @@ releases:
 {{- if env "TELEPORT_SAML_ENTITY_DESCRIPTOR" }}
   - ./values/teleport-ent/teleport-ent-saml-connector.yaml.gotmpl
 {{- end }}
-  - image:
+    ## Remaining configuration
+  - nameOverride: "teleport-auth"
+    image:
       repository: quay.io/gravitational/teleport-ent
       tag: '{{ env "TELEPORT_VERSION" | default "3.1.8" }}'
       pullPolicy: "IfNotPresent"

--- a/releases/teleport-ent-proxy.yaml
+++ b/releases/teleport-ent-proxy.yaml
@@ -35,14 +35,15 @@ releases:
   ## Configuration to be copied into Teleport container
   ## Also sets external DNS name and TLS Certificate common name
   - ./values/teleport-ent/teleport-ent-proxy.yaml.gotmpl
-  ## Remaining configuration
-  - image:
+    ## Remaining configuration
+  - name: proxy
+    nameOverride: "teleport-proxy"
+    image:
       repository: quay.io/gravitational/teleport-ent
       tag: '{{ env "TELEPORT_VERSION" | default "3.1.8" }}'
       pullPolicy: "IfNotPresent"
       # command: ["/usr/bin/dumb-init"]
       # args:  ["teleport", "start", "--insecure-no-tls", "-c", "/etc/teleport/teleport.yaml"]
-    name: proxy
 
     replicaCount: 1
 


### PR DESCRIPTION
## what
Use "teleport" rather than "teleport-ent" as prefix in Kubernetes names and labels

## why
Make life a little easier for operations and reporting