### PR TITLE
[teleport-ent] Include newline at end of config files

### DIFF
--- a/releases/values/teleport-ent/teleport-ent-auth.yaml.gotmpl
+++ b/releases/values/teleport-ent/teleport-ent-auth.yaml.gotmpl
@@ -15,7 +15,7 @@ service:
 
 ## teleport config file
 config:
-  teleport.yaml: |-
+  teleport.yaml: |
     # This section of the configuration file applies to all teleport services
     teleport:
       # nodename allows to assign an alternative name this node can be reached by
@@ -135,7 +135,7 @@ config:
       license_file: "/etc/teleport/license.pem"
 
   ## License file
-  license.pem: |-
+  license.pem: |
 {{ requiredEnv "TELEPORT_LICENSE_PEM" | trim | indent 4 }}
 
 bootstrap:

--- a/releases/values/teleport-ent/teleport-ent-proxy.yaml.gotmpl
+++ b/releases/values/teleport-ent/teleport-ent-proxy.yaml.gotmpl
@@ -20,7 +20,7 @@ service:
 config:
   ## Proxy service config file
   ## See https://gravitational.com/teleport/docs/admin-guide/#configuration-file
-  teleport.yaml: |-
+  teleport.yaml: |
     teleport:
       # nodename allows to assign an alternative name this node can be reached by
       # by default it's equal to hostname

--- a/releases/values/teleport-ent/teleport-ent-roles.yaml.gotmpl
+++ b/releases/values/teleport-ent/teleport-ent-roles.yaml.gotmpl
@@ -3,7 +3,7 @@
 bootstrap:
   resources:
     ## Roles
-    root.yaml: |-
+    root.yaml: |
       kind: "role"
       version: "v3"
       metadata:
@@ -23,7 +23,7 @@ bootstrap:
           rules:
             - resources: ["*"]
               verbs: ["*"]
-    admin.yaml: |-
+    admin.yaml: |
       kind: "role"
       version: "v3"
       metadata:
@@ -53,7 +53,7 @@ bootstrap:
               verbs: [delete]
             - resources: [trusted_cluster]
               verbs: [create, update]
-    view.yaml: |-
+    view.yaml: |
       kind: "role"
       version: "v3"
       metadata:

--- a/releases/values/teleport-ent/teleport-ent-saml-connector.yaml.gotmpl
+++ b/releases/values/teleport-ent/teleport-ent-saml-connector.yaml.gotmpl
@@ -3,7 +3,7 @@
 bootstrap:
   resources:
     ## Connector config
-    saml-connector.yaml: |-
+    saml-connector.yaml: |
       kind: saml
       version: v2
       metadata:
@@ -17,5 +17,5 @@ bootstrap:
           - {name: "groups", value: "SSH-Admin", roles: ["admin"]}
           - {name: "groups", value: "SSH-User", roles: ["view"]}
         acs: "https://{{ requiredEnv "TELEPORT_PROXY_DOMAIN_NAME" }}/v1/webapi/saml/acs"
-        entity_descriptor: |-
+        entity_descriptor: |
 {{ env "TELEPORT_SAML_ENTITY_DESCRIPTOR" | trim | indent 10 }}


### PR DESCRIPTION
## what
Include newlines at end of generated config files

## why
Sometimes the lack of a final newline in a config file can cause problems with utilities operating on the file