### PR TITLE
[teleport-ent] Support for private clusters, better maintenance ops

### DIFF
--- a/releases/teleport-ent-auth.yaml
+++ b/releases/teleport-ent-auth.yaml
@@ -37,7 +37,9 @@ releases:
   ## Configuration to be copied into Teleport container
   - ./values/teleport-ent/teleport-ent-proxy.yaml.gotmpl
   - ./values/teleport-ent/teleport-ent-auth.yaml.gotmpl
+{{- if eq (env "TELEPORT_LOAD_ROLES" | default "false") "true" }}
   - ./values/teleport-ent/teleport-ent-roles.yaml.gotmpl
+{{- end }}
 {{- if env "TELEPORT_SAML_ENTITY_DESCRIPTOR" }}
   - ./values/teleport-ent/teleport-ent-saml-connector.yaml.gotmpl
 {{- end }}
@@ -49,6 +51,7 @@ releases:
       pullPolicy: "IfNotPresent"
       # command: ["/usr/bin/dumb-init"]
       # args:  ["teleport", "start", "--insecure-no-tls", "-c", "/etc/teleport/teleport.yaml"]
+    replicaCount: {{ env "TELEPORT_AUTH_REPLICA_COUNT" | default 1 }}
     rbac:
       create: true
     serviceAccount:

--- a/releases/teleport-ent-proxy.yaml
+++ b/releases/teleport-ent-proxy.yaml
@@ -29,7 +29,7 @@ releases:
     vendor: "teleport"
     default: "true"
   chart: "cloudposse-incubator/teleport-ent-proxy"
-  version: "0.1.0"
+  version: "0.2.0"
   wait: true
   values:
   ## Configuration to be copied into Teleport container
@@ -45,22 +45,27 @@ releases:
       # command: ["/usr/bin/dumb-init"]
       # args:  ["teleport", "start", "--insecure-no-tls", "-c", "/etc/teleport/teleport.yaml"]
 
-    replicaCount: 1
+    replicaCount: {{ env "TELEPORT_PROXY_REPLICA_COUNT" | default 2 }}
 
     tls:
-      ## Enable mounting of TLS certificates from a secret
+      ## Enable mounting of TLS certificates from a secret NOT FULLY IMPLEMENTED
       ## If disabled, teleport proxy will generate self signed certs on launch
+{{- if env "TELEPORT_SSL_CERTIFICATE_ARN" }}
       enabled: false
-
-      ## Ingress to perform tls certification verifications through
-      ## See http://docs.cert-manager.io/en/latest/tutorials/acme/http-validation.html
-      ingressClass: secondary
+      useSelfSignedCert: false
+{{- else }}
+      enabled: true
+      useSelfSignedCert: true
+{{- end }}
+      ### Ingress to perform tls certification verifications through
+      ### See http://docs.cert-manager.io/en/latest/tutorials/acme/http-validation.html
+      #ingressClass: secondary
 
       ## Issue to use for tls certificates
-      issuer:
-        # name: letsencrypt-staging
-        name: letsencrypt-production
-        type: ClusterIssuer
+      #issuer:
+      #  # name: letsencrypt-staging
+      #  name: letsencrypt-production
+      #  type: ClusterIssuer
 
       ## Domain the certificate will be for
       # commonName: # set in ./values/teleport-ent/teleport-ent-proxy.yaml.gotmpl
@@ -70,18 +75,20 @@ releases:
       # secretName:
 
     service:
+{{- if env "TELEPORT_SSL_CERTIFICATE_ARN" }}
       type: LoadBalancer
       ## See https://kubernetes.io/docs/tutorials/services/source-ip
       externalTrafficPolicy: "Local"
       annotations:
         service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
-        service.beta.kubernetes.io/aws-load-balancer-ssl-ports: 443,3080
-        service.beta.kubernetes.io/aws-load-balancer-ssl-negotiation-policy: ELBSecurityPolicy-TLS-1-2-2017-01
         # service.beta.kubernetes.io/aws-load-balancer-type: nlb
         # external-dns.alpha.kubernetes.io/hostname: # set in ./values/teleport-ent/teleport-ent-proxy.yaml.gotmpl
-{{- if env "TELEPORT_SSL_CERTIFICATE_ARN" }}
+        service.beta.kubernetes.io/aws-load-balancer-ssl-ports: 443,3080
+        service.beta.kubernetes.io/aws-load-balancer-ssl-negotiation-policy: ELBSecurityPolicy-TLS-1-2-2017-01
         service.beta.kubernetes.io/aws-load-balancer-ssl-cert: '{{ env "TELEPORT_SSL_CERTIFICATE_ARN" }}'
-      external_ssl_cert: true
+        # service.beta.kubernetes.io/aws-load-balancer-type: nlb
+{{- else }}
+      type: ClusterIP
 {{- end }}
     ## Enable Teleport proxy diagnostics port
     ## This is required for liveness/readiness probes

--- a/releases/values/teleport-ent/teleport-ent-auth.yaml.gotmpl
+++ b/releases/values/teleport-ent/teleport-ent-auth.yaml.gotmpl
@@ -71,13 +71,13 @@ config:
       # defines the types and second factors the auth server supports
       authentication:
         # type can be local or oidc or saml
-{{- if env "TELEPORT_SAML_ENTITY_DESCRIPTOR" }}
+{{- if eq (env "TELEPORT_USE_SAML" | default "false") "true" }}
         type: saml
+        second_factor: off
 {{- else }}
         type: local
-{{- end }}
         # second_factor can be off, otp, or u2f
-        second_factor: otp
+        second_factor: {{ env "TELEPORT_LOCAL_SECOND_FACTOR" | default "off" }}
 
         # this section is only used if using u2f
         u2f:
@@ -88,6 +88,7 @@ config:
           facets:
           - https://0.0.0.0
           - https://0.0.0.0:3080
+{{- end }}
 
       # Determines if SSH sessions to cluster nodes are forcefully terminated
       # after no activity from a client (idle client).


### PR DESCRIPTION
## what
- Support private teleport clusters that delegate access and authentication to a trusted cluster
- Make some bootstrap operations disabled by default and enabled only ephemerally 

## why
- Further secure a cluster by making it inaccessible directly from the internet
- Avoid disturbing existing configuration during updates are redeployments