### PR TITLE
[teleport-ent-proxy] Increase load balancer idle timeout

### DIFF
--- a/releases/teleport-ent-proxy.yaml
+++ b/releases/teleport-ent-proxy.yaml
@@ -81,6 +81,8 @@ releases:
       externalTrafficPolicy: "Local"
       annotations:
         service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
+        # Set idle timeout in seconds as a string https://github.com/kubernetes/kubernetes/issues/68083#issuecomment-438304439
+        service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "900"
         # service.beta.kubernetes.io/aws-load-balancer-type: nlb
         # external-dns.alpha.kubernetes.io/hostname: # set in ./values/teleport-ent/teleport-ent-proxy.yaml.gotmpl
         service.beta.kubernetes.io/aws-load-balancer-ssl-ports: 443,3080


### PR DESCRIPTION
## what
[teleport-ent-proxy] Increase load balancer idle timeout

## why
Maximum time a Teleport session can be idle is limited by the load balancer idle timeout. This increases it to 15 minutes.