### PR TITLE
[datadog] Allow user to provision static cluster secret token

### DIFF
--- a/releases/datadog.yaml
+++ b/releases/datadog.yaml
@@ -64,6 +64,8 @@ releases:
         image:
           ### Version of cluster agent from https://hub.docker.com/r/datadog/cluster-agent/tags
           tag: {{ env "DATADOG_CLUSTER_AGENT_IMAGE_TAG" | default "latest" }}
+        # token: A cluster-internal secret for agent-to-agent communication. Must be 32+ characters a-zA-Z
+        token: {{ env "DATADOG_CLUSTER_AGENT_TOKEN" }}
         resources:
           limits:
             cpu: "256m"


### PR DESCRIPTION
## what
[datadog] Allow user to provision static cluster secret token for Datadog

## why
The Datadog cluster agent requires a secret token to protect communication with other agents. If one is not provided one will be generated by `helm`, but in that case it will be different every time, causing helm to update the deployment every time it is run, defeating the principle that helm charts should be idempotent. What is even worse, every time the secret changes, the pods must be restarted, but that does not happen by default. As a result, without the token, the Datadog release requires special treatment and sticks out when used as part of a set of releases. 