### PR TITLE
[kiam] Install required annotation along with kiam

### DIFF
--- a/releases/kiam.yaml
+++ b/releases/kiam.yaml
@@ -125,11 +125,15 @@ releases:
   recreatePods: false
   installed: {{ env "KIAM_INSTALLED" | default "true" }}
   hooks:
-   # This hook adds the annotation that instructs stakater/reloader to watch the DaemonSet's secrets and configmaps
-   # and reload the DeamonSet when they change.
-   - events: ["cleanup"]
-     command: "/bin/sh"
-     args: ["-c", "kubectl annotate --overwrite DaemonSet --selector=app=kiam reloader.stakater.com/auto=true"]
+    # This hoook adds the annotation that allows pods in the kube-system namespace to assume any annotated role
+    - events: ["prepare"]
+      command: "/bin/sh"
+      args: ["-c", "kubectl annotate --overwrite namespace kube-system 'iam.amazonaws.com/permitted=.*'"]
+    # This hook adds the annotation that instructs stakater/reloader to watch the DaemonSet's secrets and configmaps
+    # and reload the DeamonSet when they change.
+    - events: ["cleanup"]
+      command: "/bin/sh"
+      args: ["-c", "kubectl annotate --overwrite DaemonSet --selector=app=kiam reloader.stakater.com/auto=true"]
   values:
     - rbac:
         ### Optional: RBAC_ENABLED;


### PR DESCRIPTION
## what
When installing `kiam`, also install the annotation for the `kube-system` namespace to allow pods to assume IAM roles
## why
This used to be done in scripts along with the manual install of `kiam` TLS certificates, but now that certificates are automated with `cert-manager`, this step was not being done.