### PR TITLE
[teleport-ent] Satisfy RBAC requirements for Teleport v3.2

### DIFF
--- a/releases/teleport-ent-auth.yaml
+++ b/releases/teleport-ent-auth.yaml
@@ -56,9 +56,9 @@ releases:
       # args:  ["teleport", "start", "--insecure-no-tls", "-c", "/etc/teleport/teleport.yaml"]
     replicaCount: {{ env "TELEPORT_AUTH_REPLICA_COUNT" | default 1 }}
     rbac:
-      create: true
+      create: false
     serviceAccount:
-      create: true
+      create: false
     diagnostics:
       # If diagnostics are not enabled, heath and readiness checks will not be performed
       enabled: true

--- a/releases/teleport-ent-proxy.yaml
+++ b/releases/teleport-ent-proxy.yaml
@@ -28,8 +28,9 @@ releases:
     namespace: "teleport"
     vendor: "teleport"
     default: "false"
-  chart: "cloudposse-incubator/teleport-ent-proxy"
-  version: "0.2.0"
+  # chart: "cloudposse-incubator/teleport-ent-proxy"
+  chart: "/Users/jgro/CP_dev/charts/incubator/teleport-ent-proxy"
+  version: "0.3.0"
   wait: true
   force: true
   installed: {{ env "TELEPORT_PROXY_INSTALLED" | default "true" }}
@@ -48,6 +49,11 @@ releases:
       # args:  ["teleport", "start", "--insecure-no-tls", "-c", "/etc/teleport/teleport.yaml"]
 
     replicaCount: {{ env "TELEPORT_PROXY_REPLICA_COUNT" | default 2 }}
+    # RBAC and serviceAccount are required for proxy for Kubernetes integration starting with Teleport 3.2.0
+    rbac:
+      create: true
+    serviceAccount:
+      create: true
 
     tls:
       ## Enable mounting of TLS certificates from a secret NOT FULLY IMPLEMENTED

--- a/releases/values/teleport-ent/teleport-ent-auth.yaml.gotmpl
+++ b/releases/values/teleport-ent/teleport-ent-auth.yaml.gotmpl
@@ -1,6 +1,6 @@
 ## Teleport Auth chart configuration
 
-{{- $authurl := env "TELEPORT_AUTH_DOMAIN_NAME" | default (print "auth." (requiredEnv "TELEPORT_PROXY_DOMAIN_NAME")) }}
+{{- $authdomain := env "TELEPORT_AUTH_DOMAIN_NAME" | default (print "auth." (requiredEnv "TELEPORT_PROXY_DOMAIN_NAME")) }}
 
 extraArgs:
   ## enable debug
@@ -11,7 +11,7 @@ podAnnotations:
 
 service:
   annotations:
-     external-dns.alpha.kubernetes.io/hostname: "{{ $authurl }}."
+     external-dns.alpha.kubernetes.io/hostname: "{{ $authdomain }}."
 
 ## teleport config file
 config:
@@ -101,7 +101,7 @@ config:
       listen_addr: 0.0.0.0:3025
 
       # The optional DNS name the auth server if located behind a load balancer.
-      public_addr: {{ $authurl }}
+      public_addr: {{ $authdomain }}
 
       # Pre-defined tokens for adding new nodes to a cluster. Each token specifies
       # the role a new node will be allowed to assume. The more secure way to

--- a/releases/values/teleport-ent/teleport-ent-proxy.yaml.gotmpl
+++ b/releases/values/teleport-ent/teleport-ent-proxy.yaml.gotmpl
@@ -1,7 +1,7 @@
 ## Teleport Proxy chart configuration
 
-{{- $authurl := env "TELEPORT_AUTH_DOMAIN_NAME" | default (print "auth." (requiredEnv "TELEPORT_PROXY_DOMAIN_NAME")) }}
-{{- $proxyurl := (requiredEnv "TELEPORT_PROXY_DOMAIN_NAME") }}
+{{- $authdomain := env "TELEPORT_AUTH_DOMAIN_NAME" | default (print "auth." (requiredEnv "TELEPORT_PROXY_DOMAIN_NAME")) }}
+{{- $proxydomain := (requiredEnv "TELEPORT_PROXY_DOMAIN_NAME") }}
 
 extraArgs:
   ## enable debug
@@ -9,11 +9,11 @@ extraArgs:
 
 tls:
   ## Request TLS certificate for the following domain
-  commonName: {{ $proxyurl }}
+  commonName: {{ $proxydomain }}
 
 service:
   annotations:
-    external-dns.alpha.kubernetes.io/hostname: "{{ $proxyurl }}."
+    external-dns.alpha.kubernetes.io/hostname: "{{ $proxydomain }}."
 
 ## Configuration to be copied into Teleport container
 ## Each entry must be an inline file that will be written to /etc/teleport
@@ -43,7 +43,7 @@ config:
       # list of auth servers in a cluster. you will have more than one auth server
       # if you configure teleport auth to run in HA configuration
       auth_servers:
-      - "{{- $authurl }}:3025"
+      - "{{- $authdomain }}:3025"
 
       # Teleport throttles all connections to avoid abuse. These settings allow
       # you to adjust the default limits
@@ -81,7 +81,7 @@ config:
       # The DNS name the proxy server is accessible by cluster users. Defaults to
       # the proxy's hostname if not specified. It is highly recommended to set it
       # to something meaningful when running multiple proxies behind a load balancer.
-      public_addr: {{ $proxyurl }}:443
+      public_addr: {{ $proxydomain }}:443
 
       # TLS certificate for the HTTPS connection. Configuring these properly is
       # critical for Teleport security.
@@ -91,12 +91,13 @@ config:
       kubernetes:
         enabled: yes
         # public_addr can be a scalar or list. this is the domain name seen as
-        # "Kubernetes API endpoint" from the outside. If using trusted clusters, this will
+        # "Kubernetes API endpoint" from the outside. If using trusted clusters in Teleport 3.1.x, this will
         # be a concatenation of the cluster name with the trusted proxy's domain name.
         # That concatenated name will have to resolve to this proxy's public address.
         # If you are using a load balancer in front of several proxies, all the domain names
-        # need to map to the load balancer address
-        public_addr: {{ env "TELEPORT_KUBERNETES_ENDPOINTS" | default $proxyurl }}
+        # need to map to the load balancer address. If you are using Teleport 3.2 or later,
+        # you can just use the public name of the proxy and have a *.proxydomain DNS CNAME for it.
+        public_addr: {{ env "TELEPORT_KUBERNETES_ENDPOINTS" | default $proxydomain }}
         # the listen address is what Teleport/Kubernetes proxy will listen on:
         listen_addr: 0.0.0.0:3026
 


### PR DESCRIPTION
## what
[teleport-ent] Satisfy RBAC requirements for Teleport v3.2
## why
[Teleport v3.2](https://github.com/gravitational/teleport/releases/tag/v3.2.0) switched from using the CSR API on the auth server to using the impersonation API on the proxy server in order to grant access to Kubernetes resources. This requires new RBAC permissions for the proxy server.
## references
https://github.com/gravitational/teleport/commit/aefe8860c108ab91a3836832e5013274a3353620#diff-98bdb67a508f59c119f00a0aaaeaef13
https://github.com/gravitational/teleport/blob/aefe8860c108ab91a3836832e5013274a3353620/examples/chart/teleport/templates/clusterrole.yaml
