### PR TITLE
[teleport] Fix default Teleport version

### DIFF
--- a/releases/teleport-ent-auth.yaml
+++ b/releases/teleport-ent-auth.yaml
@@ -50,7 +50,7 @@ releases:
   - nameOverride: "teleport-auth"
     image:
       repository: quay.io/gravitational/teleport-ent
-      tag: '{{ env "TELEPORT_VERSION" | default "3.1.8" }}'
+      tag: '{{ env "TELEPORT_VERSION" | default "3.2.2" }}'
       pullPolicy: "IfNotPresent"
       # command: ["/usr/bin/dumb-init"]
       # args:  ["teleport", "start", "--insecure-no-tls", "-c", "/etc/teleport/teleport.yaml"]

--- a/releases/teleport-ent-proxy.yaml
+++ b/releases/teleport-ent-proxy.yaml
@@ -43,7 +43,7 @@ releases:
     nameOverride: "teleport-proxy"
     image:
       repository: quay.io/gravitational/teleport-ent
-      tag: '{{ env "TELEPORT_VERSION" | default "3.1.8" }}'
+      tag: '{{ env "TELEPORT_VERSION" | default "3.2.2" }}'
       pullPolicy: "IfNotPresent"
       # command: ["/usr/bin/dumb-init"]
       # args:  ["teleport", "start", "--insecure-no-tls", "-c", "/etc/teleport/teleport.yaml"]


### PR DESCRIPTION
## what
Fix default Teleport version to be one that works with other default settings
## why
#117 modified the `teleport` release to work with Teleport version 3.2, which had breaking changes compared to version 3.1. However, it did not upgrade the default version of Teleport to install. As a result, the default configuration did not work. This fixes that.