### PR TITLE
[prometheus-operator] switch from coreos to official helm stable chart

### DIFF
--- a/releases/keycloak-gatekeeper.yaml
+++ b/releases/keycloak-gatekeeper.yaml
@@ -4,13 +4,14 @@ repositories:
   url: "https://gabibbo97.github.io/charts/"
 
 ######
-# You need to create a keycloak-gatekeeper.yaml file with an array of services, with values that do not use go templating
-# See values/keycloak-gatekeeper.yaml for an example
+# You need to create a keycloak-gatekeeper-services.yaml file with an array of services,
+# with values that do not use go templating
+# See values/keycloak-gatekeeper-services.yaml for an example
 #
 environments:
   default:
     values:
-     - ../keycloak-gatekeeper.yaml
+      - {{ env "KEYCLOAK_GATEKEEPER_SERVICES_YAML" | default "keycloak-gatekeeper-services.yaml" }}
 
 releases:
 
@@ -36,7 +37,9 @@ releases:
     vendor: "keycloak"
     default: "false"
   chart: "gabibbo97/keycloak-gatekeeper"
-  version: "1.1.1"
+  # chart: "cloudposse-keycloak-gatekeeper-chart/keycloak-gatekeeper"
+  # chart: "/Users/jgro/CP_dev/keycloak-gatekeeper-chart/charts/keycloak-gatekeeper"
+  version: "1.2.0"
   wait: false
   installed: true
   values:
@@ -47,6 +50,9 @@ releases:
       pullPolicy: "IfNotPresent"
     debug: {{ index $service "debug" | default "false" }}
     replicas: {{ index $service "replicas" | default 1 }}
+    logging: false
+    sessionCookies: false
+    droolsPolicyEnabled: false
     ingress:
       enabled: '{{ env "KEYCLOAK_GATEKEEPER_INGRESS_ENABLED" | default "true" }}'
       annotations:
@@ -70,12 +76,21 @@ releases:
     skipUpstreamTlsVerify: {{ index $service "skipUpstreamTlsVerify" | default "false" }}
     ClientID: '{{- coalesce (env "KEYCLOAK_GATEKEEPER_CLIENT_ID") (env "KOPS_OIDC_CLIENT_ID") "kubernetes" }}'
     ClientSecret: '{{- requiredEnv "KEYCLOAK_GATEKEEPER_CLIENT_SECRET" }}'
+    # If encryption key is not provided, one will be generated, but it will change on each install
+    # Should be 16 or 32 ASCII characters for for AES-128/AES-256
+    encryptionKey: {{ env "KEYCLOAK_GATEKEEPER_ENCRYPTION_KEY" | quote }}
     scopes:
       - roles
     rules:
       {{- range $i, $rule := $service.rules }}
       - "{{ $rule }}"
       {{- end }}
+    {{- if index $service "extraArgs" }}
+    extraArgs:
+      {{- range $i, $arg := $service.extraArgs }}
+      - {{ $arg }}
+      {{- end }}
+    {{- end }}
     ### Optional: RBAC_ENABLED;
     rbac:
       create: {{ env "RBAC_ENABLED" | default "false" }}

--- a/releases/keycloak-gatekeeper.yaml
+++ b/releases/keycloak-gatekeeper.yaml
@@ -37,8 +37,6 @@ releases:
     vendor: "keycloak"
     default: "false"
   chart: "gabibbo97/keycloak-gatekeeper"
-  # chart: "cloudposse-keycloak-gatekeeper-chart/keycloak-gatekeeper"
-  # chart: "/Users/jgro/CP_dev/keycloak-gatekeeper-chart/charts/keycloak-gatekeeper"
   version: "1.2.0"
   wait: false
   installed: true

--- a/releases/nginx-ingress.yaml
+++ b/releases/nginx-ingress.yaml
@@ -213,5 +213,5 @@ releases:
           grafana_dashboard: "true"
         files:
           nginx-ingress.json: |
-{{ exec "curl" (list "-sSL" (print "https://raw.githubusercontent.com/cloudposse/grafana-dashboards/" (env "GRAFANA_DASHBOARDS_VERSION" | default "1.0") "/nginx-ingress/nginx.json")) | indent 12 }}
+{{ exec "curl" (list "-fsSL" (print "https://raw.githubusercontent.com/cloudposse/grafana-dashboards/" (env "GRAFANA_DASHBOARDS_VERSION" | default "1.0") "/nginx-ingress/nginx.json")) | indent 12 }}
 {{ end }}

--- a/releases/nginx-ingress.yaml
+++ b/releases/nginx-ingress.yaml
@@ -170,14 +170,15 @@ releases:
     vendor: "cloudposse"
     default: {{ env "NGINX_INGRESS_METRICS_ENABLED" | default "false" }}
   chart: "cloudposse-incubator/monochart"
-  version: "0.4.0"
+  version: "0.10.0"
   wait: true
   installed: {{ env "NGINX_INGRESS_METRICS_INSTALLED" | default "true" }}
   values:
   - prometheusRules:
       nginx-ingress:
         labels:
-          prometheus: kube-prometheus
+          app: prometheus-operator
+          release: prometheus-operator
         groups:
         - name: nginx-ingress.rules
           rules:
@@ -192,7 +193,8 @@ releases:
     serviceMonitors:
       nginx-ingress:
         labels:
-          prometheus: kube-prometheus
+          app: prometheus-operator
+          release: prometheus-operator
         selector:
           matchLabels:
             app: nginx-ingress
@@ -209,8 +211,7 @@ releases:
         enabled: true
         labels:
           grafana_dashboard: "true"
-
-  set:
-  - name: "configMaps.dashboards.files.nginx\\.json"
-    file: https://raw.githubusercontent.com/cloudposse/grafana-dashboards/{{ env "GRAFANA_DASHBOARDS_VERSION" | default "1.0" }}/nginx-ingress/nginx.json
+        files:
+          nginx-ingress.json: |
+{{ exec "curl" (list "-sSL" (print "https://raw.githubusercontent.com/cloudposse/grafana-dashboards/" (env "GRAFANA_DASHBOARDS_VERSION" | default "1.0") "/nginx-ingress/nginx.json")) | indent 12 }}
 {{ end }}

--- a/releases/prometheus-operator.yaml
+++ b/releases/prometheus-operator.yaml
@@ -76,11 +76,11 @@ releases:
         logLevel: "warn"
         resources:
           limits:
-            cpu: '{{ env "PROMETHEUS_OPERATOR_LIMIT_CPU" | default "10m" }}'
-            memory: '{{ env "PROMETHEUS_OPERATOR_LIMIT_MEMORY" | default "64Mi" }}'
+            cpu: '{{ env "PROMETHEUS_OPERATOR_LIMIT_CPU" | default "100m" }}'
+            memory: '{{ env "PROMETHEUS_OPERATOR_LIMIT_MEMORY" | default "96Mi" }}'
           requests:
-            cpu: '{{ env "PROMETHEUS_OPERATOR_REQUEST_CPU" | default "5m" }}'
-            memory: '{{ env "PROMETHEUS_OPERATOR_REQUEST_MEMORY" | default "32Mi" }}'
+            cpu: '{{ env "PROMETHEUS_OPERATOR_REQUEST_CPU" | default "20m" }}'
+            memory: '{{ env "PROMETHEUS_OPERATOR_REQUEST_MEMORY" | default "48Mi" }}'
         image:
           pullPolicy: "IfNotPresent"
       prometheus:
@@ -96,21 +96,44 @@ releases:
           logLevel: "warn"
           scrapeInterval: ""
           evaluationInterval: ""
-          externalUrl: "http://{{- print "prometheus." (env "KOPS_CLUSTER_NAME") }}"
+          ## If true, a nil or {} value for prometheus.prometheusSpec.ruleSelector will cause the
+          ## prometheus resource to be created with selectors based on values in the helm deployment,
+          ## which will also match the PrometheusRule resources created.
+          ## If false, a nil or or {} value for ruleSelector will select all PrometheusRule resources.
+          ruleSelectorNilUsesHelmValues: false
+          ## serviceMonitorSelectorNilUsesHelmValues works just like ruleSelectorNilUsesHelmValues
+          serviceMonitorSelectorNilUsesHelmValues: false
+          externalUrl: "{{- env "PROMETHEUS_PROMETHEUS_EXTERNAL_URL" | default (print "https://api." (env "KOPS_CLUSTER_NAME") "/api/v1/namespaces/monitoring/services/prometheus-operator-prometheus:web/proxy/") }}"
+          resources:
+            limits:
+              cpu: '{{ env "PROMETHEUS_PROMETHEUS_LIMIT_CPU" | default "300m" }}'
+              memory: '{{ env "PROMETHEUS_PROMETHEUS_LIMIT_MEMORY" | default "1Gi" }}'
+            requests:
+              cpu: '{{ env "PROMETHEUS_PROMETHEUS_REQUEST_CPU" | default "50m" }}'
+              memory: '{{ env "PROMETHEUS_PROMETHEUS_REQUEST_MEMORY" | default "512Mi" }}'
       alertmanager:
         enabled: {{ env "ALERTMANAGER_INSTALLED" | default "true" }}
         alertmanagerSpec:
-          externalUrl: "http://{{- print "alertmanager." (env "KOPS_CLUSTER_NAME") }}"
+          externalUrl: "{{- env "PROMETHEUS_ALERTMANAGER_EXTERNAL_URL" | default (print "https://api." (env "KOPS_CLUSTER_NAME") "/api/v1/namespaces/monitoring/services/prometheus-operator-alertmanager:web/proxy/") }}"
+          resources:
+            limits:
+              cpu: '{{ env "PROMETHEUS_ALERTMANAGER_LIMIT_CPU" | default "200m" }}'
+              memory: '{{ env "PROMETHEUS_ALERTMANAGER_LIMIT_MEMORY" | default "96Mi" }}'
+            requests:
+              cpu: '{{ env "PROMETHEUS_ALERTMANAGER_REQUEST_CPU" | default "10m" }}'
+              memory: '{{ env "PROMETHEUS_ALERTMANAGER_REQUEST_MEMORY" | default "24Mi" }}'
       grafana:
         enabled: {{ env "GRAFANA_INSTALLED" | default "true" }}
         adminPassword: {{ env "GRAFANA_ADMIN_PASSWORD" | default "prom-operator" }}
         grafana.ini:
           server:
             # root_url: "https://api.{{- env "KOPS_CLUSTER_NAME" }}/api/v1/namespaces/kube-system/services/prometheus-operator-grafana:service/proxy/"
-            root_url: "http://{{- print "grafana." (env "KOPS_CLUSTER_NAME") }}"
+            root_url: "{{- env "PROMETHEUS_GRAFANA_ROOT_URL" | default (print "https://api." (env "KOPS_CLUSTER_NAME") "/api/v1/namespaces/monitoring/services/prometheus-operator-grafana:service/proxy/") }}"
+          {{- if eq (env "PROMETHEUS_ANONYMOUS_ADMIN_ENABLED" | default "true") "true" }}
           auth.anonymous:
             enabled: true
             org_role: Admin
+          {{- end }}
       kubeApiServer:
         enabled: true
       kubelet:

--- a/releases/prometheus-operator.yaml
+++ b/releases/prometheus-operator.yaml
@@ -115,6 +115,19 @@ releases:
         enabled: true
       kubelet:
         enabled: true
+        # In general, few clusters are set up to allow kublet to authenticate a bearer token, and
+        # the HTTPS endpoint requires authentication, so Prometheus cannot access it.
+        # The HTTP endpoint does not require authentication, so Prometheus can access it.
+        # See https://github.com/coreos/prometheus-operator/issues/926
+        https: {{ env "PROMETHEUS_KUBELET_HTTPS" | default "false" }}
+      kubeControllerManager:
+        enabled: true
+        {{- if eq (env "PROMETHEUS_KUBE_K8S_APP_LABEL_NAME" | default "false") "true" }}
+        service:
+          selector:
+            k8s-app: "kube-controller-manager"
+            component: null
+        {{- end }}
       coreDns:
         enabled: {{ coalesce (env "PROMETHEUS_EXPORTER_CORE_DNS_ENABLED") "true" }}
       kubeDns:
@@ -123,6 +136,12 @@ releases:
         enabled: true
       kubeScheduler:
         enabled: true
+        {{- if eq (env "PROMETHEUS_KUBE_K8S_APP_LABEL_NAME" | default "false") "true" }}
+        service:
+          selector:
+            k8s-app: "kube-scheduler"
+            component: null
+        {{- end }}
       nodeExporter:
         enabled: true
     {{- if env "PROMETHEUS_ADDITIONAL_CONFIG_YAML" }}

--- a/releases/prometheus-operator.yaml
+++ b/releases/prometheus-operator.yaml
@@ -1,65 +1,130 @@
+#####
+# WARNING: This is a complete rewrite of this release as we switch from
+# the deprecated coreos-stable chart at https://github.com/coreos/prometheus-operator/tree/master/helm/prometheus-operator
+# to the current helm stable chart at https://github.com/helm/charts/tree/master/stable/prometheus-operator
+#
+# OLD References:
+# OLD  - https://github.com/coreos/prometheus-operator/tree/master/helm/prometheus-operator
+# OLD  - https://github.com/coreos/prometheus-operator
+#
 repositories:
-# CoreOS Stable helm charts
-- name: "coreos-stable"
-  url: "https://s3-eu-west-1.amazonaws.com/coreos-charts/stable"
+  # Official helm charts
+  - name: "stable"
+    url: "https://kubernetes-charts.storage.googleapis.com/"
 
 releases:
 
-#######################################################################################
-## prometheus-operator                                                               ##
-## creates/configures/manages Prometheus clusters atop Kubernetes                    ##
-#######################################################################################
+  #######################################################################################
+  ## prometheus-operator                                                               ##
+  ## creates/configures/manages Prometheus clusters atop Kubernetes                    ##
+  ## This is the all-in-one version that                                               ##
+  ## replaces https://github.com/coreos/prometheus-operator/tree/master/helm           ##
+  #######################################################################################
 
-#
-# References:
-#   - https://github.com/coreos/prometheus-operator/tree/master/helm/prometheus-operator
-#   - https://github.com/coreos/prometheus-operator
-#
-- name: "prometheus-operator"
-  namespace: "kube-system"
-  labels:
-    chart: "prometheus-operator"
-    repo: "coreos-stable"
-    component: "monitoring"
-    namespace: "kube-system"
-    vendor: "coreos"
-    default: "true"
-  chart: "coreos-stable/prometheus-operator"
-  version: "0.0.29"
-  wait: true
-  installed: {{ env "PROMETHEUS_OPERATOR_INSTALLED" | default "true" }}
-  values:
-      ### Optional: RBAC_ENABLED;
-    - rbacEnable: {{ env "RBAC_ENABLED" | default "false" }}
-      jobLabel: "prometheus-operator"
-      image:
-        repository: "quay.io/coreos/prometheus-operator"
-        ### Optional: PROMETHEUS_OPERATOR_IMAGE_TAG; e.g. v0.20.0
-        tag: '{{ env "PROMETHEUS_OPERATOR_IMAGE_TAG" | default "v0.23.2" }}'
-        pullPolicy: "IfNotPresent"
-      resources:
-        limits:
-          cpu: '{{ env "PROMETHEUS_OPERATOR_LIMIT_CPU" | default "10m" }}'
-          memory: '{{ env "PROMETHEUS_OPERATOR_LIMIT_MEMORY" | default "64Mi" }}'
-        requests:
-          cpu: '{{ env "PROMETHEUS_OPERATOR_REQUEST_CPU" | default "5m" }}'
-          memory: '{{ env "PROMETHEUS_OPERATOR_REQUEST_MEMORY" | default "32Mi" }}'
-      global:
-        hyperkube:
-          repository: "quay.io/coreos/hyperkube"
-          ### Optional: PROMETHEUS_OPERATOR_GLOBAL_HYPERKUBE_IMAGE_TAG; e.g. v1.7.6_coreos.0
-          tag: '{{ env "PROMETHEUS_OPERATOR_GLOBAL_HYPERKUBE_IMAGE_TAG" | default "v1.7.6_coreos.0" }}'
+  #
+  # References:
+  #   - https://github.com/helm/charts/tree/master/stable/prometheus-operator
+  #   - https://github.com/coreos/prometheus-operator
+  #
+  - name: "prometheus-operator"
+    namespace: "monitoring"
+    labels:
+      chart: "prometheus-operator"
+      repo: "coreos-stable"
+      component: "monitoring"
+      namespace: "monitoring"
+      vendor: "coreos"
+      default: "true"
+    chart: "stable/prometheus-operator"
+    version: "5.5.0"
+    wait: true
+    installed: {{ env "PROMETHEUS_OPERATOR_INSTALLED" | default "true" }}
+    hooks:
+    # This hoook installs the prometheuses.monitoring.coreos.com CustomResourceDefinition if needed
+    - events: ["prepare"]
+      command: "/bin/sh"
+      args: ["-c", "kubectl get crd prometheuses.monitoring.coreos.com >/dev/null 2>&1 || \
+             kubectl apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/master/example/prometheus-operator-crd/prometheus.crd.yaml"]
+    # This hoook installs the alertmanagers.monitoring.coreos.com CustomResourceDefinition if needed
+    - events: ["prepare"]
+      command: "/bin/sh"
+      args: ["-c", "kubectl get crd alertmanagers.monitoring.coreos.com >/dev/null 2>&1 || \
+             kubectl apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/master/example/prometheus-operator-crd/alertmanager.crd.yaml"]
+    # This hoook installs the prometheusrules.monitoring.coreos.com CustomResourceDefinition if needed
+    - events: ["prepare"]
+      command: "/bin/sh"
+      args: ["-c", "kubectl get crd prometheusrules.monitoring.coreos.com >/dev/null 2>&1 || \
+             kubectl apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/master/example/prometheus-operator-crd/prometheusrule.crd.yaml"]
+    # This hoook installs the servicemonitors.monitoring.coreos.com CustomResourceDefinition if needed
+    - events: ["prepare"]
+      command: "/bin/sh"
+      args: ["-c", "kubectl get crd servicemonitors.monitoring.coreos.com >/dev/null 2>&1 || \
+             kubectl apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/master/example/prometheus-operator-crd/servicemonitor.crd.yaml"]
+    values:
+    - global:
+        rbac:
+          create: {{ env "RBAC_ENABLED" | default "true" }}
+          pspEnabled: {{ coalesce (env "POD_SECURITY_POLICY_ENALBED") (env "RBAC_ENABLED") "true" }}
+      defaultRules:
+        create: true
+      additionalPrometheusRules: []
+      prometheusOperator:
+        enabled: {{ env "PROMETHEUS_OPERATOR_INSTALLED" | default "true" }}
+        ### Create CRDs separately
+        createCustomResource: false
+        # log level must be one of "all", "debug",	"info", "warn",	"error", "none"
+        logLevel: "warn"
+        resources:
+          limits:
+            cpu: '{{ env "PROMETHEUS_OPERATOR_LIMIT_CPU" | default "10m" }}'
+            memory: '{{ env "PROMETHEUS_OPERATOR_LIMIT_MEMORY" | default "64Mi" }}'
+          requests:
+            cpu: '{{ env "PROMETHEUS_OPERATOR_REQUEST_CPU" | default "5m" }}'
+            memory: '{{ env "PROMETHEUS_OPERATOR_REQUEST_MEMORY" | default "32Mi" }}'
+        image:
           pullPolicy: "IfNotPresent"
-      prometheusConfigReloader:
-        repository: "quay.io/coreos/prometheus-config-reloader"
-        ### Optional: PROMETHEUS_OPERATOR_PROMETHEUS_CONFIG_RELOADER_IMAGE_TAG; e.g. v0.20.0
-        tag: '{{ env "PROMETHEUS_OPERATOR_PROMETHEUS_CONFIG_RELOADER_IMAGE_TAG" | default "v0.23.2" }}'
-      configmapReload:
-        repository: "quay.io/coreos/configmap-reload"
-        ### Optional: PROMETHEUS_OPERATOR_CONFIGMAP_RELOAD_IMAGE_TAG; e.g. v0.0.1
-        tag: '{{ env "PROMETHEUS_OPERATOR_CONFIGMAP_RELOAD_IMAGE_TAG" | default "v0.0.1" }}'
-      kubeletService:
-        # If enabled, prometheus-operator will create a service for scraping kubelets
-        enable: true
-        namespace: "kube-system"
-        name: "kubelet"
+      prometheus:
+        enabled: {{ env "PROMETHEUS_OPERATOR_INSTALLED" | default "true" }}
+        podDisruptionBudget:
+          enabled: false
+        ingress:
+          enabled: false
+        additionalServiceMonitors: []
+        prometheusSpec:
+          replicas: 1
+          retention: 45d
+          logLevel: "warn"
+          scrapeInterval: ""
+          evaluationInterval: ""
+          externalUrl: "http://{{- print "prometheus." (env "KOPS_CLUSTER_NAME") }}"
+      alertmanager:
+        enabled: {{ env "ALERTMANAGER_INSTALLED" | default "true" }}
+        alertmanagerSpec:
+          externalUrl: "http://{{- print "alertmanager." (env "KOPS_CLUSTER_NAME") }}"
+      grafana:
+        enabled: {{ env "GRAFANA_INSTALLED" | default "true" }}
+        adminPassword: {{ env "GRAFANA_ADMIN_PASSWORD" | default "prom-operator" }}
+        grafana.ini:
+          server:
+            # root_url: "https://api.{{- env "KOPS_CLUSTER_NAME" }}/api/v1/namespaces/kube-system/services/prometheus-operator-grafana:service/proxy/"
+            root_url: "http://{{- print "grafana." (env "KOPS_CLUSTER_NAME") }}"
+          auth.anonymous:
+            enabled: true
+            org_role: Admin
+      kubeApiServer:
+        enabled: true
+      kubelet:
+        enabled: true
+      coreDns:
+        enabled: {{ coalesce (env "PROMETHEUS_EXPORTER_CORE_DNS_ENABLED") "true" }}
+      kubeDns:
+        enabled: {{ coalesce (env "PROMETHEUS_EXPORTER_KUBE_DNS_ENABLED") "false" }}
+      kubeEtcd:
+        enabled: true
+      kubeScheduler:
+        enabled: true
+      nodeExporter:
+        enabled: true
+    {{- if env "PROMETHEUS_ADDITIONAL_CONFIG_YAML" }}
+    - {{ env "PROMETHEUS_ADDITIONAL_CONFIG_YAML" }}
+    {{ end }}

--- a/releases/values/keycloak-gatekeeper-services.yaml
+++ b/releases/values/keycloak-gatekeeper-services.yaml
@@ -1,5 +1,5 @@
 ######
-# Example keycloak-gatekeeper.yaml with comments. Most elements can be omitted.
+# Example keycloak-gatekeeper-services.yaml with comments. Most elements can be omitted.
 # services:
 #    - name: dashboard  # the service name
 #      portalName: "Kubernetes Dashboard"  # The name as it should appear in the Forecastle portal (omit to hide)
@@ -16,4 +16,9 @@
 #      upstream: http://forecastle.kube-system.svc.cluster.local
 #      rules:
 #        - "uri=/*|roles=kube-admin,user|require-any-role=true"
+#      extraArgs:
+#        - enable-token-header=false
+#        - enable-authorization-header=false
+#        - enable-authorization-cookies=false
+
 ######


### PR DESCRIPTION
## what
[prometheus-operator] switch from coreos to official helm stable chart
[nginx-ingress] update metrics release to work with prometheus-operator
[keycloak-gatekeeper] add options, including some needed to support Grafana
## why
Better integration among Prometheus, Grafana, and Alert Manager