### PR TITLE
Change teleport quality of service

### DIFF
--- a/releases/teleport-ent-auth.yaml
+++ b/releases/teleport-ent-auth.yaml
@@ -66,8 +66,8 @@ releases:
       debugging: false
     resources:
       limits:
-        cpu: 1000m
-        memory: 2560Mi
+        cpu: 100m
+        memory: 128Mi
       requests:
-        cpu: 20m
+        cpu: 100m
         memory: 128Mi

--- a/releases/teleport-ent-auth.yaml
+++ b/releases/teleport-ent-auth.yaml
@@ -67,7 +67,7 @@ releases:
     resources:
       limits:
         cpu: 100m
-        memory: 128Mi
+        memory: 64Mi
       requests:
         cpu: 100m
-        memory: 128Mi
+        memory: 64Mi

--- a/releases/teleport-ent-proxy.yaml
+++ b/releases/teleport-ent-proxy.yaml
@@ -116,11 +116,11 @@ releases:
 
     resources:
       limits:
-        cpu: 200m
+        cpu: 100m
         memory: 128Mi
       requests:
-        cpu: 5m
-        memory: 16Mi
+        cpu: 100m
+        memory: 128Mi
 
     nodeSelector: {}
 

--- a/releases/teleport-ent-proxy.yaml
+++ b/releases/teleport-ent-proxy.yaml
@@ -117,10 +117,10 @@ releases:
     resources:
       limits:
         cpu: 100m
-        memory: 128Mi
+        memory: 64Mi
       requests:
         cpu: 100m
-        memory: 128Mi
+        memory: 64Mi
 
     nodeSelector: {}
 


### PR DESCRIPTION
## What
* Made teleport quality of service `Guaranteed`

## Why
* To set the lowest priority GC for the pods