### PR TITLE
Kubecost release

### DIFF
--- a/releases/keycloak-gatekeeper.yaml
+++ b/releases/keycloak-gatekeeper.yaml
@@ -62,7 +62,7 @@ releases:
       annotations:
         kubernetes.io/ingress.class: nginx
         nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
-        kubernetes.io/tls-acme: "{{ index $service "useTLS" | default "false" }}"
+        kubernetes.io/tls-acme: "{{ index $service "useTLS" | default false }}"
         external-dns.alpha.kubernetes.io/target: '{{ requiredEnv "NGINX_INGRESS_HOSTNAME" }}'
         external-dns.alpha.kubernetes.io/ttl: "60"
         {{- if index $service "portalName"  }}
@@ -75,9 +75,9 @@ releases:
 {{- end }}
       {{- end }}
       hosts: [{{- $service.host }}]
-      {{- if eq (index $service "useTLS" | default "false") "true" }}
+      {{- if (index $service "useTLS" | default false) }}
       tls:
-        - secretName: "key-gate-{{- $service.name }}"
+        - secretName: "key-gate-{{- $service.name }}-tls"
           hosts: [{{- $service.host }}]
       {{- end }}
     discoveryURL: '{{- coalesce (env "KEYCLOAK_GATEKEEPER_DISCOVERY_URL") (env "KOPS_OIDC_ISSUER_URL") }}'

--- a/releases/kubecost.yaml
+++ b/releases/kubecost.yaml
@@ -60,7 +60,6 @@ releases:
             datasources:
               enabled: true
       {{- end }}
-{{- if eq (env "PROMETHEUS_OPERATOR_INSTALLED" | default "true") "true" }}
 # References:
 #   - https://github.com/helm/charts/tree/master/incubator/raw
 #
@@ -70,6 +69,7 @@ releases:
     version: "0.2.3"
     wait: true
     force: true
+    installed: {{ env "PROMETHEUS_OPERATOR_INSTALLED" | default "true" }}
     values:
     - resources:
       - apiVersion: monitoring.coreos.com/v1
@@ -89,4 +89,3 @@ releases:
             scrapeTimeout: 10s
             metrics_path: /metrics
             scheme: http
-{{- end }}

--- a/releases/kubecost.yaml
+++ b/releases/kubecost.yaml
@@ -1,0 +1,92 @@
+repositories:
+  # kubecost has their own helm repo
+  - name: "kubecost"
+    url: "https://kubecost.github.io/cost-analyzer/"
+# Kubernetes incubator repo of helm charts
+  - name: "kubernetes-incubator"
+    url: "https://kubernetes-charts-incubator.storage.googleapis.com"
+
+releases:
+  #######################################################################################
+  ## kubecost                                                                          ##
+  ## Kubecost is a cost analyzer for kubernetes cloud resrouces                        ##
+  #######################################################################################
+
+  #
+  # References:
+  #   - https://github.com/kubecost/cost-analyzer-helm-chart/blob/master/cost-analyzer/values.yaml
+  #   - http://docs.kubecost.com
+  #
+  - name: "kubecost"
+    namespace: "monitoring"
+    labels:
+      chart: "kubecost"
+      repo: "github"
+      component: "kubecost"
+      namespace: "monitoring"
+      vendor: "kubecost"
+      default: "false"
+    chart: "kubecost/cost-analyzer"
+    version: "v1.26.0"
+    wait: true
+    installed: {{ env "KUBECOST_INSTALLED" | default "true" }}
+    values:
+      {{- if eq (env "PROMETHEUS_OPERATOR_INSTALLED" | default "true") "true" }}
+      - global:
+          prometheus:
+            enabled: false # If false, Prometheus will not be installed
+            fqdn: http://prometheus-operator-prometheus.monitoring.svc.cluster.local:9090
+          grafana:
+            enabled: false # If false, Grafana will not be installed
+            domainName: {{ env "PROMETHEUS_GRAFANA_ROOT_DOMAIN" | default "prometheus-operator-grafana.monitoring.svc.cluster.local" }}
+            scheme: {{ env "PROMETHEUS_GRAFANA_ROOT_SCHEME" | default "http" }}
+            proxy: false
+        grafana:
+          sidecar:
+            dashboards:
+              enabled: true
+            datasources:
+              enabled: false
+      {{- else }}
+      - global:
+          prometheus:
+            enabled: true
+          grafana:
+            enabled: true # If false, Grafana will not be installed
+        grafana:
+          sidecar:
+            dashboards:
+              enabled: true
+            datasources:
+              enabled: true
+      {{- end }}
+{{- if eq (env "PROMETHEUS_OPERATOR_INSTALLED" | default "true") "true" }}
+# References:
+#   - https://github.com/helm/charts/tree/master/incubator/raw
+#
+  - name: 'cost-analyzer-model'
+    chart: "kubernetes-incubator/raw"
+    namespace: monitoring
+    version: "0.2.3"
+    wait: true
+    force: true
+    values:
+    - resources:
+      - apiVersion: monitoring.coreos.com/v1
+        kind: ServiceMonitor
+        metadata:
+          name: cost-analyzer-model
+          labels:
+            release: prometheus-operator
+        spec:
+          selector:
+            matchLabels:
+              chart: cost-analyzer-1.26.0
+          endpoints:
+          - honorLabels: true
+            port: cost-analyzer-model
+            interval: 1m
+            scrapeTimeout: 10s
+            metrics_path: /metrics
+            scheme: http
+{{- end }}

--- a/releases/prometheus-operator.yaml
+++ b/releases/prometheus-operator.yaml
@@ -152,6 +152,18 @@ releases:
             enabled: true
             org_role: Admin
           {{- end }}
+      kubeStateMetrics:
+        enabled: true
+      {{- if or (env "PROMETHEUS_OPERATOR_KSM_IMAGE_REPOSITORY") (env "PROMETHEUS_OPERATOR_KSM_IMAGE_TAG") }}
+      kube-state-metrics:
+        image:
+          {{- if env "PROMETHEUS_OPERATOR_KSM_IMAGE_REPOSITORY" }}
+          repository: {{ env "PROMETHEUS_OPERATOR_KSM_IMAGE_REPOSITORY" }}
+          {{- end }}
+          {{- if env "PROMETHEUS_OPERATOR_KSM_IMAGE_TAG" }}
+          tag: {{ env "PROMETHEUS_OPERATOR_KSM_IMAGE_TAG" }}
+          {{- end }}
+      {{- end }}
       kubeApiServer:
         enabled: true
       kubelet:
@@ -175,7 +187,15 @@ releases:
       kubeDns:
         enabled: {{ coalesce (env "PROMETHEUS_EXPORTER_KUBE_DNS_ENABLED") "false" }}
       kubeEtcd:
-        enabled: true
+        # Access to etcd is a huge security risk, so nodes are blocked from accessing it.
+        # Therefore Prometheus cannot access it without extra setup, which is beyond the scope of this helmfile.
+        # See https://github.com/kubernetes/kops/issues/5852
+        #     https://github.com/kubernetes/kops/issues/4975#issuecomment-381055946
+        #     https://github.com/coreos/prometheus-operator/issues/2397
+        #     https://github.com/coreos/prometheus-operator/blob/v0.19.0/contrib/kube-prometheus/docs/Monitoring%20external%20etcd.md
+        #     https://gist.github.com/jhohertz/476bd616d4171649a794b8c409f8d548
+        # So we disable it since it is not going to work anyway
+        enabled: false
       kubeScheduler:
         enabled: true
         {{- if eq (env "PROMETHEUS_KUBE_K8S_APP_LABEL_NAME" | default "false") "true" }}

--- a/releases/prometheus-operator.yaml
+++ b/releases/prometheus-operator.yaml
@@ -128,6 +128,12 @@ releases:
       grafana:
         enabled: {{ env "GRAFANA_INSTALLED" | default "true" }}
         adminPassword: {{ env "GRAFANA_ADMIN_PASSWORD" | default "prom-operator" }}
+        defaultDashboardsEnabled: true
+        sidecar:
+          dashboards:
+            enabled: true
+            searchNamespace: ALL
+            defaultFolderName: "AutoLoaded"
         grafana.ini:
           server:
             # root_url: "https://api.{{- env "KOPS_CLUSTER_NAME" }}/api/v1/namespaces/kube-system/services/prometheus-operator-grafana:service/proxy/"

--- a/releases/prometheus-operator.yaml
+++ b/releases/prometheus-operator.yaml
@@ -94,6 +94,15 @@ releases:
           enabled: false
         additionalServiceMonitors: []
         prometheusSpec:
+          {{- if or (env "PROMETHEUS_OPERATOR_PROMETHEUS_IMAGE_REPOSITORY") (env "PROMETHEUS_OPERATOR_PROMETHEUS_IMAGE_TAG") }}
+          image:
+            {{- if env "PROMETHEUS_OPERATOR_PROMETHEUS_IMAGE_REPOSITORY" }}
+            repository: {{ env "PROMETHEUS_OPERATOR_PROMETHEUS_IMAGE_REPOSITORY" }}
+            {{- end }}
+            {{- if env "PROMETHEUS_OPERATOR_PROMETHEUS_IMAGE_TAG" }}
+            tag: {{ env "PROMETHEUS_OPERATOR_PROMETHEUS_IMAGE_TAG" }}
+            {{- end }}
+          {{- end }}
           replicas: 1
           retention: 45d
           logLevel: "warn"


### PR DESCRIPTION
## what
- Install [`kubecost`](https://github.com/kubecost/cost-analyzer-helm-chart) with support from [`prometheus-operator`](https://github.com/helm/charts/tree/ede60d8bf09dfc0ad5d262874b5373275c538620/stable/prometheus-operator)
- Remove ineffective attempt to have `prometheus` monitor `etcd`
## why
- Track cost of AWS resources used by the cluster
- Access to etcd is a huge security risk, so nodes are blocked from accessing it. Therefore Prometheus cannot access it without extra setup, which is beyond the scope of this helmfile. So we disable it since it was not working anyway and was instead taking up resources and generating clutter. See:
  - https://github.com/kubernetes/kops/issues/5852
  - https://github.com/kubernetes/kops/issues/4975#issuecomment-381055946
  - https://github.com/coreos/prometheus-operator/issues/2397
  - https://github.com/coreos/prometheus-operator/blob/v0.19.0/contrib/kube-prometheus/docs/Monitoring%20external%20etcd.md
  - https://gist.github.com/jhohertz/476bd616d4171649a794b8c409f8d548

## notes
This release of `prometheus-operator` installs [`kube-state-metrics`](https://github.com/kubernetes/kube-state-metrics) v1.5.0, but `kubecost` uses metrics [introduced in v1.6.0](https://github.com/kubernetes/kube-state-metrics/releases/tag/v1.6.0), in particular `kube_persistentvolume_capacity_bytes`, so there are some blank graphs because of that.

Also, this release installs `kubecost` v1.26, which has 1 known bug in the Namespace utilization metrics Grafana dashboard, causing the Overall RAM Utilization chart to be empty. 

This release installs a `ServiceMonitor` resource to cause Prometheus to scrape the Kubecost `cost-analyzer`. 
- This is fragile, because the service monitor has to target a service by label, not name, and the only label on the service is `cost-analyzer-1.26.0` which presumably will change with the next release.
- Ideally Kubecost would install the ServiceMonitor resource.
- See https://github.com/kubecost/cost-analyzer-helm-chart/issues/48

This release does not install any `PrometheusRule` resources. Again, these should be installed by the `Kubecost` chart but are not as yet.