### PR TITLE
[codefresh-account] Allow Codefresh to create namespaces for unlimited staging

### DIFF
--- a/releases/codefresh-account.yaml
+++ b/releases/codefresh-account.yaml
@@ -29,7 +29,8 @@ releases:
   wait: true
   installed: {{ env "CODEFRESH_SERVICE_ACCOUNT_INSTALLED" | default "true" }}
   values:
-  - clusterrole:
+  - fullnameOverride: "codefresh-service-account"
+    clusterrole:
       rules:
         - apiGroups: ["batch"]
           resources: ["jobs", "cronjobs"]
@@ -49,7 +50,7 @@ releases:
         - apiGroups: [""]
           resources: ["namespaces"]
 {{ if eq (env "CODEFRESH_SERVICE_ACCOUNT_UNLIMITED_STAGING_ENABLED" | default "false") "true" }}
-          verbs: ["get", "list", "update", "patch", "delete"]
+          verbs: ["create", "get", "list", "update", "patch", "delete"]
 {{ else }}
           verbs: ["get", "list", "update", "patch"]
 {{ end }}


### PR DESCRIPTION
## what
[codefresh-account] Allow Codefresh to create namespaces for unlimited staging

## why
Each unlimited staging environment is in its own namespace, and Codefresh needs to be able to create that namespace explicitly if it wants to customize it before deploying helmfile releases or helm charts. 