### PR TITLE
[kubecost] Use `ServiceMonitor` from the Kubecost helm chart

### DIFF
--- a/releases/kubecost.yaml
+++ b/releases/kubecost.yaml
@@ -31,6 +31,8 @@ releases:
     wait: true
     installed: {{ env "KUBECOST_INSTALLED" | default "true" }}
     values:
+      - serviceMonitor:
+          enabled: true
       {{- if eq (env "PROMETHEUS_OPERATOR_INSTALLED" | default "true") "true" }}
       - global:
           prometheus:
@@ -60,32 +62,3 @@ releases:
             datasources:
               enabled: true
       {{- end }}
-  # References:
-  #   - https://github.com/helm/charts/tree/master/incubator/raw
-  #
-  - name: 'cost-analyzer-model'
-    chart: "kubernetes-incubator/raw"
-    namespace: monitoring
-    version: "0.2.3"
-    wait: true
-    force: true
-    installed: {{ env "PROMETHEUS_OPERATOR_INSTALLED" | default "true" }}
-    values:
-      - resources:
-          - apiVersion: monitoring.coreos.com/v1
-            kind: ServiceMonitor
-            metadata:
-              name: cost-analyzer-model
-              labels:
-                release: prometheus-operator
-            spec:
-              selector:
-                matchLabels:
-                  chart: cost-analyzer-1.32.0
-              endpoints:
-                - honorLabels: true
-                  port: cost-analyzer-model
-                  interval: 1m
-                  scrapeTimeout: 10s
-                  metrics_path: /metrics
-                  scheme: http


### PR DESCRIPTION
## what
* [kubecost] Use `ServiceMonitor` from the Kubecost helm chart

## why
* Native support for `ServiceMonitor` was added in `v1.29.0`

## references
* https://github.com/kubecost/cost-analyzer-helm-chart/pull/63
