### PR TITLE
explicit namespace for annotate command

### DIFF
--- a/releases/kiam.yaml
+++ b/releases/kiam.yaml
@@ -133,7 +133,7 @@ releases:
     # and reload the DeamonSet when they change.
     - events: ["cleanup"]
       command: "/bin/sh"
-      args: ["-c", "kubectl annotate --overwrite DaemonSet --selector=app=kiam reloader.stakater.com/auto=true"]
+      args: ["-c", "kubectl annotate --overwrite --namespace={{ .Namespace }} DaemonSet --selector=app=kiam reloader.stakater.com/auto=true"]
   values:
     - rbac:
         ### Optional: RBAC_ENABLED;


### PR DESCRIPTION
## what 
* annotate command have to use namespace 

## why
* default namespace would be using if not set it explicitly