### PR TITLE
[kiam] Fix hook (again)

### DIFF
--- a/releases/kiam.yaml
+++ b/releases/kiam.yaml
@@ -133,7 +133,7 @@ releases:
     # and reload the DeamonSet when they change.
     - events: ["postsync"]
       command: "/bin/sh"
-      args: ["-c", "kubectl annotate --overwrite --namespace={{ .Namespace }} DaemonSet --selector=app=kiam reloader.stakater.com/auto=true"]
+      args: ["-c", "kubectl annotate --overwrite --namespace={{`{{ .Release.Namespace }}`}} DaemonSet --selector=app=kiam reloader.stakater.com/auto=true"]
   values:
     - rbac:
         ### Optional: RBAC_ENABLED;


### PR DESCRIPTION
## what
[kiam] Fix `postsync` helmfile hook (again)

## why
1. Hooks are run through 2 Go template steps, so need to be Go quoted
1. `{{ .Namespace }}` is not available (or not the right thing) in the hook