### PR TITLE
[cert-manager] Upgrade to v0.9.0, create issuers

### DIFF
--- a/releases/cert-manager.yaml
+++ b/releases/cert-manager.yaml
@@ -1,22 +1,25 @@
 repositories:
-# Cloud Posse incubator repo of helm charts
-- name: "cloudposse-incubator"
-  url: "https://charts.cloudposse.com/incubator/"
-
+# Add the Jetstack Helm repository
+- name: jetstack
+  url: "https://charts.jetstack.io"
+  # Kubernetes incubator repo of helm charts
+- name: "kubernetes-incubator"
+  url: "https://kubernetes-charts-incubator.storage.googleapis.com"
 
 releases:
 
-################################################################################
-## CERT-MANAGER - Automatic Let's Encrypt for Ingress  #########################
-##   Also provides local CA for issuing locally valid TLS certificates  ########
-################################################################################
+###############################################################################
+## CERT-MANAGER - Automatic Let's Encrypt for Ingress  ########################
+##   Also provides local CA for issuing locally valid TLS certificates  #######
+##   Replaces kube-lego                                                 #######
+###############################################################################
 
 #
 # References:
-# - https://github.com/helm/charts/blob/master/stable/cert-manager/values.yaml
-# - https://github.com/jetstack/cert-manager/blob/release-0.7/deploy/charts/cert-manager/values.yaml
+# - https://github.com/jetstack/cert-manager/blob/v0.9.0/deploy/charts/cert-manager/values.yaml
+# Instructions for installing and testing correct install are at
+# - https://docs.cert-manager.io/en/release-0.9/getting-started/install/kubernetes.html
 #
-# Instructions for testing correct install are at
 - name: "cert-manager"
   namespace: "cert-manager"
   labels:
@@ -26,10 +29,28 @@ releases:
     namespace: "cert-manager"
     vendor: "jetstack"
     default: "false"
-  chart: "cloudposse-incubator/cert-manager"
-  version: "v0.7.0"
+  chart: "jetstack/cert-manager"
+  version: "v0.9.0"
   wait: true
   installed: {{ env "CERT_MANAGER_INSTALLED" | default "true" }}
+  hooks:
+    # This hoook adds the CRDs
+    - events: ["presync"]
+      showlogs: true
+      command: "/bin/sh"
+      args: ["-c", "kubectl apply -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.9/deploy/manifests/00-crds.yaml"]
+    # This hook adds the annotation that keeps the webhook from preventing its own installation
+    - events: ["presync"]
+      showlogs: true
+      command: "/bin/sh"
+      args:
+      - "-c"
+      - >-
+        kubectl get namespace "{{`{{ .Release.Namespace }}`}}" >/dev/null 2>&1 || kubectl create namespace "{{`{{ .Release.Namespace }}`}}";
+        kubectl label --overwrite namespace "{{`{{ .Release.Namespace }}`}}" "certmanager.k8s.io/disable-validation=true" ;
+        [[ "{{`{{ .Release.Namespace }}`}}" = "cert-manager" ]] && [[ -n "${CERT_MANAGER_IAM_ROLE}" ]]
+        && kubectl annotate namespace "{{`{{ .Release.Namespace }}`}}" "iam.amazonaws.com/permitted=${CERT_MANAGER_IAM_ROLE}"
+        || echo + Not annotating namespace "{{`{{ .Release.Namespace }}`}}" with "iam.amazonaws.com/permitted=${CERT_MANAGER_IAM_ROLE}"
   values:
     - fullnameOverride: cert-manager
       rbac:
@@ -40,14 +61,33 @@ releases:
         defaultIssuerName: '{{ env "CERT_MANAGER_INGRESS_SHIM_DEFAULT_ISSUER_NAME" | default "letsencrypt-prod" }}'
         ### Optional: CERT_MANAGER_INGRESS_SHIM_DEFAULT_ISSUER_KIND;
         defaultIssuerKind: '{{ env "CERT_MANAGER_INGRESS_SHIM_DEFAULT_ISSUER_KIND" | default "ClusterIssuer" }}'
-      tolerations:
-        - key: "node-role.kubernetes.io/node"
-          effect: "NoSchedule"
+        # defaultIssuerName: ""
+        # defaultIssuerKind: ""
+        # defaultACMEChallengeType: ""
+        # defaultACMEDNS01ChallengeProvider: ""
+{{ if env "CERT_MANAGER_IAM_ROLE" | default "" }}
+      podAnnotations:
+        ### Required: EXTERNAL_DNS_IAM_ROLE; e.g. cp-staging-external-dns
+        iam.amazonaws.com/role: '{{ env "CERT_MANAGER_IAM_ROLE" }}'
+{{ end }}
       serviceAccount:
         ### Optional: RBAC_ENABLED;
         create: {{ env "RBAC_ENABLED" | default "false" }}
         ### Optional: CERT_MANAGER_SERVICE_ACCOUNT_NAME;
         name: '{{ env "CERT_MANAGER_SERVICE_ACCOUNT_NAME" | default "" }}'
+      prometheus:
+        enabled: true
+        servicemonitor:
+          enabled: true
+          prometheusInstance: default
+          targetPort: 9402
+          path: /metrics
+          interval: 60s
+          scrapeTimeout: 30s
+      webhook:
+        enabled: true
+      cainjector:
+        enabled: true
       resources:
         limits:
           cpu: "200m"
@@ -55,3 +95,65 @@ releases:
         requests:
           cpu: "50m"
           memory: "128Mi"
+- name: 'cert-manager-issuers'
+  chart: "kubernetes-incubator/raw"
+  namespace: "cert-manager"
+  labels:
+    component: "iam"
+    namespace: "cert-manager"
+    default: "true"
+  version: "0.1.0"
+  wait: true
+  force: true
+  recreatePods: true
+  installed: {{ env "CERT_MANAGER_INSTALLED" | default "true" }}
+  values:
+  - resources:
+    - apiVersion: certmanager.k8s.io/v1alpha1
+      kind: ClusterIssuer
+      metadata:
+        name: letsencrypt-staging
+      spec:
+        acme:
+          # The ACME server URL
+          server: https://acme-staging-v02.api.letsencrypt.org/directory
+          # Email address used for ACME registration
+          email: {{ coalesce (env "CERT_MANAGER_EMAIL") (env "KUBE_LEGO_EMAIL") "user@example.com" }}
+          # Name of a secret used to store the ACME account private key
+          privateKeySecretRef:
+            name: letsencrypt-staging
+          solvers:
+            # Enable the HTTP-01 challenge provider
+            - http01:
+                ingress:
+                  class: nginx
+{{- if env "CERT_MANAGER_IAM_ROLE" | default "" }}
+            # Enable the DNS-01 challenge provider
+            - dns01:
+                route53: {}
+{{- end }}
+    - apiVersion: certmanager.k8s.io/v1alpha1
+      kind: ClusterIssuer
+      metadata:
+        name: letsencrypt-prod
+      spec:
+        acme:
+          # The ACME server URL
+          server: https://acme-v02.api.letsencrypt.org/directory
+          # Email address used for ACME registration
+          email: {{ coalesce (env "CERT_MANAGER_EMAIL") (env "KUBE_LEGO_EMAIL") "user@example.com" }}
+          # Name of a secret used to store the ACME account private key
+          privateKeySecretRef:
+            name: letsencrypt-prod
+          solvers:
+            # Enable the HTTP-01 challenge provider
+            - http01:
+                ingress:
+                  class: nginx
+{{- if env "CERT_MANAGER_IAM_ROLE" | default "" }}
+            # Enable the DNS-01 challenge provider
+            - dns01:
+                route53: {}
+{{- end }}
+
+


### PR DESCRIPTION
## what
[cert-manager] Upgrade to v0.9.0, create `ClusterIssuers` for Let's Encrypt.
## why
Replace obsolete `kube-lego` with current `cert-manager` for TLS certificate management.