### PR TITLE
Add user roles, update kubecost

### DIFF
--- a/releases/keycloak-gatekeeper.yaml
+++ b/releases/keycloak-gatekeeper.yaml
@@ -28,12 +28,12 @@ releases:
 #
 {{ range $index, $service := .Environment.Values.services }}
 - name: "key-gate-{{- $service.name }}"
-  namespace: "kube-system"
+  namespace: '{{- env "KEYCLOAK_GATEKEEPER_NAMESPACE" | default "kube-system" }}'
   labels:
     chart: "keycloak-gatekeeper"
     repo: "gabibbo97"
     component: "iap"
-    namespace: "kube-system"
+    namespace: '{{- env "KEYCLOAK_GATEKEEPER_NAMESPACE" | default "kube-system" }}'
     vendor: "keycloak"
     default: "false"
   chart: "gabibbo97/keycloak-gatekeeper"
@@ -44,7 +44,7 @@ releases:
   - nameOverride: "key-gate-{{- $service.name }}"
     fullNameOverride: "key-gate-{{- $service.name }}"
     image:
-      tag: 5.0.0
+      tag: 6.0.1
       pullPolicy: "IfNotPresent"
     debug: {{ index $service "debug" | default "false" }}
     replicas: {{ index $service "replicas" | default 1 }}
@@ -71,6 +71,9 @@ releases:
         {{- end }}
         {{- if index $service "forecastleInstanceName"  }}
         forecastle.stakater.com/instance: "{{ $service.forecastleInstanceName }}"
+        {{- end }}
+        {{- if index $service "forecastleGroupName"  }}
+        forecastle.stakater.com/group: "{{ $service.forecastleGroupName }}"
         {{- end }}
         {{- if index $service "ingressAnnotations" }}
 {{- with $service.ingressAnnotations }}

--- a/releases/kubecost.yaml
+++ b/releases/kubecost.yaml
@@ -27,21 +27,23 @@ releases:
       vendor: "kubecost"
       default: "false"
     chart: "kubecost/cost-analyzer"
-    version: "v1.32.0"
+    version: "v1.37.0"
     wait: true
     installed: {{ env "KUBECOST_INSTALLED" | default "true" }}
     values:
       - serviceMonitor:
           enabled: true
+      - prometheusRule:
+          enabled: true
       {{- if eq (env "PROMETHEUS_OPERATOR_INSTALLED" | default "true") "true" }}
       - global:
           prometheus:
             enabled: false # If false, Prometheus will not be installed
-            fqdn: http://prometheus-operator-prometheus.monitoring.svc.cluster.local:9090
+            fqdn: '{{- env "PROMETHEUS_PROMETHEUS_SCHEME" | default "http" }}://{{- env "PROMETHEUS_PROMETHEUS_DOMAIN" | default "prometheus-operator-prometheus.monitoring.svc.cluster.local" }}:{{- env "PROMETHEUS_PROMETHEUS_PORT" | default "9090" }}'
           grafana:
             enabled: false # If false, Grafana will not be installed
-            domainName: {{ env "PROMETHEUS_GRAFANA_ROOT_DOMAIN" | default "prometheus-operator-grafana.monitoring.svc.cluster.local" }}
-            scheme: {{ env "PROMETHEUS_GRAFANA_ROOT_SCHEME" | default "http" }}
+            domainName: {{ env "PROMETHEUS_GRAFANA_DOMAIN" | default "prometheus-operator-grafana.monitoring.svc.cluster.local" }}
+            scheme: {{ env "PROMETHEUS_GRAFANA_SCHEME" | default "http" }}
             proxy: false
         grafana:
           sidecar:

--- a/releases/oidc-ingress.yaml
+++ b/releases/oidc-ingress.yaml
@@ -273,7 +273,7 @@ releases:
           {{- if env "FORECASTLE_INSTANCE_NAME" }}
           forecastle.stakater.com/instance: "{{ env "FORECASTLE_INSTANCE_NAME" }}"
           {{- end }}
-          forecastle.stakater.com/group: kube-system
+          forecastle.stakater.com/group: "{{ env "OIDC_INGRESS_FORECASTLE_GROUP" | default "portal" }}"
           kubernetes.io/ingress.class: '{{ env "OIDC_INGRESS_NGINX_CLASS" | default "oidc-ingress" }}'
           kubernetes.io/tls-acme: "false"
         name: oidc-ingress-portal

--- a/releases/oidc-role.yaml
+++ b/releases/oidc-role.yaml
@@ -26,12 +26,79 @@ releases:
       - apiVersion: rbac.authorization.k8s.io/v1
         kind: ClusterRoleBinding
         metadata:
-          name: {{ env "OIDC_ROLE_ROLE_NAME" | default "oidc-role" }}
+          name: {{ env "OIDC_ROLE_ROOT_CRB_NAME" | default "oidc-root" }}
         roleRef:
           apiGroup: rbac.authorization.k8s.io
           kind: ClusterRole
-          name: {{ env "OIDC_ROLE_CLUSTER_ROLE" | default "cluster-admin" }}
+          name: {{ env "OIDC_ROLE_ROOT_CLUSTER_ROLE" | default "cluster-admin" }}
         subjects:
         - apiGroup: rbac.authorization.k8s.io
           kind: Group
-          name: {{ env "OIDC_ROLE_CLIENT_ROLE" | default "oidc:kube-admin" }}
+          name: {{ env "OIDC_ROLE_ROOT_CLIENT_ROLE" | default "oidc:kube-admin" }}
+        - apiGroup: rbac.authorization.k8s.io
+          kind: User
+          name: {{ env "OIDC_ROLE_ROOT_CLIENT_ROLE" | default "oidc:kube-admin" }}
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRoleBinding
+        metadata:
+          name: {{ env "OIDC_ROLE_POWER_USER_CRB_NAME" | default "oidc-power-user" }}
+        roleRef:
+          apiGroup: rbac.authorization.k8s.io
+          kind: ClusterRole
+          name: {{ env "OIDC_ROLE_POWER_USER_CLUSTER_ROLE" | default "edit" }}
+        subjects:
+        - apiGroup: rbac.authorization.k8s.io
+          kind: Group
+          name: {{ env "OIDC_ROLE_POWER_USER_CLIENT_ROLE" | default "oidc:power-user" }}
+        - apiGroup: rbac.authorization.k8s.io
+          kind: User
+          name: {{ env "OIDC_ROLE_POWER_USER_CLIENT_ROLE" | default "oidc:power-user" }}
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRoleBinding
+        metadata:
+          name: {{ env "OIDC_ROLE_OBSERVER_CRB_NAME" | default "oidc-observer" }}
+        roleRef:
+          apiGroup: rbac.authorization.k8s.io
+          kind: ClusterRole
+          name: {{ env "OIDC_ROLE_OBSERVER_CLUSTER_ROLE" | default "oidc-observer" }}
+        subjects:
+        - apiGroup: rbac.authorization.k8s.io
+          kind: Group
+          name: {{ env "OIDC_ROLE_OBSERVER_CLIENT_ROLE" | default "oidc:observer" }}
+        - apiGroup: rbac.authorization.k8s.io
+          kind: User
+          name: {{ env "OIDC_ROLE_OBSERVER_CLIENT_ROLE" | default "oidc:observer" }}
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRole
+        metadata:
+          name: {{ env "OIDC_ROLE_OBSERVER_CLUSTER_ROLE" | default "oidc-observer" }}
+        aggregationRule:
+          clusterRoleSelectors:
+            - matchLabels:
+                rbac.authorization.k8s.io/aggregate-to-view: "true"
+            - matchLabels:
+                rbac.authorization.k8s.io/aggregate-to-observer: "true"
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRole
+        metadata:
+          name: {{ env "OIDC_ROLE_OBSERVER_CLUSTER_ROLE" | default "oidc-observer" }}-extra
+          labels:
+            rbac.authorization.k8s.io/aggregate-to-observer: "true"
+        rules:
+        - apiGroups:
+            - ""
+          resources:
+            - secrets
+          verbs:
+            - list
+        - apiGroups:
+            - monitoring.coreos.com
+          resources:
+            - alertmanagers
+            - prometheuses
+            - servicemonitors
+            - prometheusrules
+          verbs:
+            - list
+            - get
+

--- a/releases/teleport-ent-auth.yaml
+++ b/releases/teleport-ent-auth.yaml
@@ -31,7 +31,7 @@ releases:
     vendor: "teleport"
     default: "false"
   chart: "cloudposse-incubator/teleport-ent-auth"
-  version: "0.1.0"
+  version: "0.1.1"
   wait: true
   # atomic is not widely supported yet, but when it is, we should use it
   # atomic: true

--- a/releases/values/teleport-ent/teleport-ent-roles.yaml.gotmpl
+++ b/releases/values/teleport-ent/teleport-ent-roles.yaml.gotmpl
@@ -53,6 +53,39 @@ bootstrap:
               verbs: [delete]
             - resources: [trusted_cluster]
               verbs: [create, update]
+    power-user.yaml: |
+      kind: "role"
+      version: "v3"
+      metadata:
+        name: "power-user"
+      spec:
+        options:
+          # max_session_ttl defines the TTL (time to live) of SSH certificates
+          # issued to the users with this role.
+          max_session_ttl: "{{ env "TELEPORT_SESSION_TTL" | default "4h" }}"
+          port_forwarding: false
+        allow:
+          # Deny SSH access
+          logins: []
+          node_labels: {}
+          ## Enable Kubernetes integration
+          kubernetes_groups: ["oidc:power-user","oidc:observer"]
+          rules:
+            - resources: ["*"]
+              verbs: ["*"]
+        deny:
+          logins: ['*']
+          node_labels:
+            "*": "*"
+          rules:
+            - resources: [role]
+              verbs: [create, update]
+            - resources: [auth_connector]
+              verbs: [create, update]
+            - resources: [session]
+              verbs: [delete]
+            - resources: [trusted_cluster]
+              verbs: [create, update]
     view.yaml: |
       kind: "role"
       version: "v3"
@@ -73,3 +106,27 @@ bootstrap:
           rules:
             - resources: [session]
               verbs: [list, read]
+    observer.yaml: |
+      kind: "role"
+      version: "v3"
+      metadata:
+        name: "observer"
+      spec:
+        options:
+          # max_session_ttl defines the TTL (time to live) of SSH certificates
+          # issued to the users with this role.
+          max_session_ttl: "{{ env "TELEPORT_SESSION_TTL" | default "4h" }}"
+          port_forwarding: false
+        allow:
+          # Deny SSH access
+          logins: []
+          node_labels: {}
+          ## Enable Kubernetes integration
+          kubernetes_groups: ["oidc:observer"]
+        deny:
+          logins: ['*']
+          node_labels:
+            "*": "*"
+          rules:
+            - resources: ["*"]
+              verbs: ["*"]


### PR DESCRIPTION
## what
1. [oidc-role][teleport-ent-auth] Add OIDC user roles of varying capability
1. [oidc-ingress] Allow Forecastle group to be set
1. [keycloak-gatekeeper] Allow `keycloak-gatekeeper` to be deployed in a namespace other than `kube-system`
1. [keycloak-gatekeeper] Update to current version 5.0.0 -> 6.0.1
1. [kubecost] Update to current version 1.32 -> 1.37

## why
1. Allow for finer grained access control, along the lines of Kubernetes `cluster-admin`, `edit`, and `view`.
1. Cosmetic
1. Too many resources cluttering `kube-system`, no real need to be in that namespace
1. Keeping up-to-date
1. Keeping up-to-date, get `PrometheusRules` as resources compatible with `prometheus-operator`