### PR TITLE
Create grafana-dashboards release

### DIFF
--- a/releases/grafana-dashboards.yaml
+++ b/releases/grafana-dashboards.yaml
@@ -1,0 +1,71 @@
+repositories:
+  # Kubernetes incubator repo of helm charts
+  - name: "kubernetes-incubator"
+    url: "https://kubernetes-charts-incubator.storage.googleapis.com"
+
+######
+# You need to create a grafana-dashboards-definitions.yaml file with an array of
+# dashboard definitions.
+# See values/grafana-dashboards-definitions.yaml for an example
+#
+environments:
+  default:
+    values:
+      - {{ env "GRAFANA_DASHBOARDS_DEFINITIONS" | default "grafana-dashboards-definitions.yaml" }}
+
+releases:
+  #
+  # Create ConfigMaps with dashboard definitions for Grafana
+  #
+  # References:
+  #   - https://github.com/helm/charts/tree/master/stable/grafana#sidecar-for-dashboards
+  #   - https://github.com/helm/charts/tree/master/incubator/raw
+  #
+  - name: 'grafana-dashboards'
+    chart: "kubernetes-incubator/raw"
+    namespace: '{{- env "GRAFANA_DASHBOARDS_NAMESPACE" | default "monitoring" }}'
+    version: "0.2.3"
+    wait: true
+    force: true
+    recreatePods: false
+    installed: {{ env "GRAFANA_DASHBOARDS_INSTALLED" | default "true" }}
+    values:
+    - resources:
+      # Provision one configmap per dashboard, do not subject
+      # JSON to template parsing
+      {{- range $name, $definition := .Environment.Values.dashboards }}
+      {{- if index $definition "json" }}
+      - kind: ConfigMap
+        apiVersion: v1
+        metadata:
+          name: {{ $name }}
+          labels:
+            grafana_dashboard: "true"
+        data:
+          {{ $name }}.json: |-
+{{ $definition.json | indent 14 }}
+      {{- end }}
+      {{- end }}
+    - templates:
+      # Provision one configmap per dashboard, using file URIs
+      {{- range $name, $definition := .Environment.Values.dashboards }}
+      {{- if index $definition "path" }}
+      - |
+        kind: ConfigMap
+        apiVersion: v1
+        metadata:
+          name: {{ $name }}
+          labels:
+            grafana_dashboard: "true"
+        data:
+          {{ $name }}.json: |-
+        {{ print "{{ (index .Values `" $name "`).json | indent 4 }}" }}
+      {{- end }}
+      {{- end }}
+    set:
+    {{- range $name, $definition := .Environment.Values.dashboards }}
+    {{- if index $definition "path" }}
+    - name: "{{- $name }}.json"
+      file: "{{- $definition.path }}"
+    {{- end }}
+    {{- end }}

--- a/releases/keycloak-gatekeeper.yaml
+++ b/releases/keycloak-gatekeeper.yaml
@@ -5,7 +5,8 @@ repositories:
 
 ######
 # You need to create a keycloak-gatekeeper-services.yaml file with an array of services,
-# with values that do not use go templating
+# with values that do not use go templating, or you can use go templating
+# by adding `.gotmpl` to the end of the file name
 # See values/keycloak-gatekeeper-services.yaml for an example
 #
 environments:

--- a/releases/keycloak.yaml
+++ b/releases/keycloak.yaml
@@ -69,7 +69,7 @@ releases:
           kubernetes.io/ingress.class: nginx
           kubernetes.io/tls-acme: "true"
           ingress.kubernetes.io/affinity: cookie
-          nginx.ingress.kubernetes.io/app-root: /auth/admin
+          nginx.ingress.kubernetes.io/app-root: /auth/admin/
           external-dns.alpha.kubernetes.io/target: '{{ requiredEnv "NGINX_INGRESS_HOSTNAME" }}'
           external-dns.alpha.kubernetes.io/ttl: "60"
           {{- if eq (env "KEYCLOAK_FORECASTLE_EXPOSE" | default "true") "true" }}

--- a/releases/nginx-ingress.yaml
+++ b/releases/nginx-ingress.yaml
@@ -61,6 +61,10 @@ releases:
             external-dns.alpha.kubernetes.io/hostname: '{{ env "NGINX_INGRESS_HOSTNAME" }}'
             ### Optional: NGINX_INGRESS_TTL; e.g. 60
             external-dns.alpha.kubernetes.io/ttl: '{{ env "NGINX_INGRESS_TTL" | default "60" }}'
+        updateStrategy:
+          rollingUpdate:
+            maxUnavailable: 1
+          type: RollingUpdate
         stats:
           enabled: {{ env "NGINX_INGRESS_METRICS_ENABLED" | default "false" }}
         metrics:

--- a/releases/prometheus-cloudwatch-exporter.yaml
+++ b/releases/prometheus-cloudwatch-exporter.yaml
@@ -1,0 +1,60 @@
+repositories:
+  # Stable repo of official helm charts
+  - name: "stable"
+    url: "https://kubernetes-charts.storage.googleapis.com"
+
+releases:
+
+  #############################################################################
+  ## prometheus-cloudwatch-exporter                                          ##
+  ## Metrics exporter for Amazon AWS CloudWatch                              ##
+  #############################################################################
+
+  # References
+  #  - https://github.com/helm/charts/tree/master/stable/prometheus-cloudwatch-exporter
+  #  - https://github.com/helm/charts/blob/master/stable/prometheus-cloudwatch-exporter/values.yaml
+  #  - https://github.com/prometheus/cloudwatch_exporter
+
+  - name: "prometheus-cloudwatch-exporter"
+    namespace: {{ env "PROMETHEUS_CLOUDWATCH_EXPORTER_IAM_NAMESPACE" | default "cloudwatch" }}
+    labels:
+      chart: "prometheus-cloudwatch-exporter"
+      repo: "stable"
+      component: "monitoring"
+      namespace: {{ env "PROMETHEUS_CLOUDWATCH_EXPORTER_IAM_NAMESPACE" | default "cloudwatch" }}
+      vendor: "kubernetes"
+      default: "false"
+    chart: "stable/prometheus-cloudwatch-exporter"
+    version: "0.4.9"
+    wait: true
+    installed: {{ env "PROMETHEUS_CLOUDWATCH_EXPORTER_INSTALLED" | default "true" }}
+    {{- if env "PROMETHEUS_CLOUDWATCH_EXPORTER_CONFIG_FILE" }}
+    set:
+    - name: config
+      file: {{ env "PROMETHEUS_CLOUDWATCH_EXPORTER_CONFIG_FILE" }}
+    {{- end }}
+    values:
+      - image:
+          repository: '{{ env "PROMETHEUS_CLOUDWATCH_EXPORTER_IMAGE_REPO" | default "prom/cloudwatch-exporter" }}'
+          tag: '{{ env "PROMETHEUS_CLOUDWATCH_EXPORTER_IMAGE_TAG" | default "cloudwatch_exporter-0.5.0" }}'
+          pullPolicy: '{{ env "PROMETHEUS_CLOUDWATCH_EXPORTER_IMAGE_PULL_POLICY" | default "IfNotPresent" }}'
+        # Leave role empty if you are not using IAM based access control
+        aws:
+          role: '{{ env "PROMETHEUS_CLOUDWATCH_EXPORTER_IAM_ROLE" | default "" }}'
+        rbac:
+          create: {{ env "RBAC_ENABLED" | default "true" }}
+        serviceAccount:
+          create: true
+          name: prometheus-cloudwatch-exporter
+        # Prometheus Operator Service Monitor
+        serviceMonitor:
+          enabled: true
+          namespace: '{{ env "PROMETHEUS_CLOUDWATCH_EXPORTER_SERVICE_MONITOR_NAMESPACE" | default "monitoring" }}'
+        resources:
+          limits:
+            cpu: '{{ env "PROMETHEUS_CLOUDWATCH_EXPORTER_LIMIT_CPU" | default "200m" }}'
+            memory: '{{ env "PROMETHEUS_CLOUDWATCH_EXPORTER_LIMIT_MEMORY" | default "256Mi" }}'
+          requests:
+            cpu: '{{ env "PROMETHEUS_CLOUDWATCH_EXPORTER_REQUEST_CPU" | default "50m" }}'
+            memory: '{{ env "PROMETHEUS_CLOUDWATCH_EXPORTER_REQUEST_MEMORY" | default "128Mi" }}'
+

--- a/releases/prometheus-operator.yaml
+++ b/releases/prometheus-operator.yaml
@@ -195,6 +195,8 @@ releases:
             enabled: true
             searchNamespace: ALL
             defaultFolderName: "AutoLoaded"
+        plugins:
+          - grafana-piechart-panel
         grafana.ini:
           server:
             # root_url: "https://api.{{- env "KOPS_CLUSTER_NAME" }}/api/v1/namespaces/kube-system/services/prometheus-operator-grafana:service/proxy/"

--- a/releases/values/grafana-dashboards-definitions.yaml
+++ b/releases/values/grafana-dashboards-definitions.yaml
@@ -1,26 +1,28 @@
-# Example dashboard definitions
-
-dashboards:
-  control-plane:
-    # path can be a URL or a file path.
-    # Sadly you cannot use URLs directly from the Grafana library due to the
-    # templating they use.
-    path: https://raw.githubusercontent.com/cloudposse/grafana-dashboards/3.0/kube-prometheus/pods-dashboard.json
-  pods:
-    # This is not a valid dashboard, just a snippet to show where
-    # the JSON goes.
-    json: |-
-      {
-        "__inputs": [
-        {
-          "description": "",
-          "label": "prometheus",
-          "name": "DS_PROMETHEUS",
-          "pluginId": "prometheus",
-          "pluginName": "Prometheus",
-          "type": "datasource"
-        }
-        ],
-        ...
-        "version": 1
-      }
+#  # Example dashboard definitions
+#
+#  dashboards:
+#    # name of ConfigMap for dashboard
+#    control-plane:
+#      # path can be a URL or a file path.
+#      # Sadly you cannot use URLs directly from the Grafana library due to the
+#      # templating they use.
+#      path: https://raw.githubusercontent.com/cloudposse/grafana-dashboards/3.0/kube-prometheus/pods-dashboard.json
+#    # name of ConfigMap for dashboard
+#    pods:
+#      # This is not a valid dashboard, just a snippet to show where
+#      # the JSON goes.
+#      json: |-
+#        {
+#          "__inputs": [
+#          {
+#            "description": "",
+#            "label": "prometheus",
+#            "name": "DS_PROMETHEUS",
+#            "pluginId": "prometheus",
+#            "pluginName": "Prometheus",
+#            "type": "datasource"
+#          }
+#          ],
+#          ...
+#          "version": 1
+#        }

--- a/releases/values/grafana-dashboards-definitions.yaml
+++ b/releases/values/grafana-dashboards-definitions.yaml
@@ -1,0 +1,26 @@
+# Example dashboard definitions
+
+dashboards:
+  control-plane:
+    # path can be a URL or a file path.
+    # Sadly you cannot use URLs directly from the Grafana library due to the
+    # templating they use.
+    path: https://raw.githubusercontent.com/cloudposse/grafana-dashboards/3.0/kube-prometheus/pods-dashboard.json
+  pods:
+    # This is not a valid dashboard, just a snippet to show where
+    # the JSON goes.
+    json: |-
+      {
+        "__inputs": [
+        {
+          "description": "",
+          "label": "prometheus",
+          "name": "DS_PROMETHEUS",
+          "pluginId": "prometheus",
+          "pluginName": "Prometheus",
+          "type": "datasource"
+        }
+        ],
+        ...
+        "version": 1
+      }

--- a/releases/values/keycloak-gatekeeper-services.yaml.gotmpl
+++ b/releases/values/keycloak-gatekeeper-services.yaml.gotmpl
@@ -1,0 +1,24 @@
+######
+# Example keycloak-gatekeeper-services.yaml with comments. Most elements can be omitted.
+# services:
+#    - name: dashboard  # the service name
+#      portalName: "Kubernetes Dashboard"  # The name as it should appear in the Forecastle portal (omit to hide)
+#      host: dashboard.{{- requiredEnv "KOPS_CLUSTER_NAME" }} # The DNS name of the public endpoint
+#      useTLS: false  # True to generate a TLS certificate and use an HTTPS endpoint
+#      upstream: https://kubernetes-dashboard.kube-system.svc.cluster.local  # The service URL
+#      skipUpstreamTlsVerify: true # True to skip the validity check of the TLS certificate of the upstream URL
+#      rules: # Array of access control rules
+#        - "uri=/*|roles=kube-admin"
+#      replicas: 1 # number of replicas
+#    - name: forecastle
+#      debug: true
+#      host: forecastle.{{- requiredEnv "KOPS_CLUSTER_NAME" }}
+#      upstream: http://forecastle.kube-system.svc.cluster.local
+#      rules:
+#        - "uri=/*|roles=kube-admin,user|require-any-role=true"
+#      extraArgs:
+#        - enable-token-header=false
+#        - enable-authorization-header=false
+#        - enable-authorization-cookies=false
+
+######


### PR DESCRIPTION
## what
1. Create `grafana-dashboards` release
1. Minor fix for [keycloak]
1. Additional example for [keycloak-gatekeeper]
1. [nginx] Change nginx update strategy from OnDelete to RollingUpdate
1. Create [`prometheus-cloudwatch-exporter`](https://github.com/prometheus/cloudwatch_exporter) release

## why
1. Easily add dashboards to [Grafana](https://github.com/helm/charts/tree/master/stable/grafana#sidecar-for-dashboards) with `helmfile`.
1. Fix bug
1. Add documentation
1. Automatically roll out changes when settings change
1. Pull metrics from CloudWatch into Prometheus