### PR TITLE
[prometheus-operator] Alertmanager template fix

### DIFF
--- a/releases/values/kube-prometheus.alerts.template
+++ b/releases/values/kube-prometheus.alerts.template
@@ -92,7 +92,6 @@
 {{ end }}
 
 {{ define "slack.default.text" }}
-  {{ /* template "__headline" . */ }}
   {{- $root :=  . -}}
   {{- if .CommonAnnotations.summary }}
 {{ .CommonAnnotations.summary }}


### PR DESCRIPTION
## what
1. [prometheus-operator] Alertmanager template fix

## why
1. Alertmanager does not like comments inside template definitions