### PR TITLE
[phpmyadmin] Parameterize `probesEnabled`. Parameterize CPU/Memory requests and limits

### DIFF
--- a/releases/phpmyadmin.yaml
+++ b/releases/phpmyadmin.yaml
@@ -48,11 +48,11 @@ releases:
         probesEnabled: {{ env "PHPMYADMIN_PROBES_ENABLED" | default "true" }}
         resources:
           limits:
-            cpu: "200m"
-            memory: "256Mi"
+            cpu: '{{ env "PHPMYADMIN_LIMIT_CPU" | default "500m" }}'
+            memory: '{{ env "PHPMYADMIN_LIMIT_MEMORY" | default "512Mi" }}'
           requests:
-            cpu: "100m"
-            memory: "128Mi"
+            cpu: '{{ env "PHPMYADMIN_REQUEST_CPU" | default "200m" }}'
+            memory: '{{ env "PHPMYADMIN_REQUEST_MEMORY" | default "256Mi" }}'
         ingress:
           enabled: {{ env "PHPMYADMIN_INGRESS_ENABLED" | default "false" }}
           annotations:

--- a/releases/phpmyadmin.yaml
+++ b/releases/phpmyadmin.yaml
@@ -45,6 +45,7 @@ releases:
           port: '{{ env "PHPMYADMIN_DB_PORT" | default "3306" }}'
           host: '{{ env "PHPMYADMIN_DB_HOST" | default "localhost" }}'
           bundleTestDB: {{ env "PHPMYADMIN_BUNDLE_TEST_DB" | default "false" }}
+        probesEnabled: {{ env "PHPMYADMIN_PROBES_ENABLED" | default "true" }}
         resources:
           limits:
             cpu: "200m"


### PR DESCRIPTION
## what
* [phpmyadmin] Parameterize `probesEnabled`
* [phpmyadmin] Parameterize CPU/Memory requests and limits


## why
* Allow users to change the parameters via ENV vars


