### PR TITLE
Update forecastle version

### DIFF
--- a/releases/forecastle.yaml
+++ b/releases/forecastle.yaml
@@ -28,7 +28,7 @@ releases:
       vendor: "stakater"
       default: "false"
     chart: "forecastle/forecastle"
-    version: "v1.0.25"
+    version: "v1.0.27"
     wait: false
     installed: {{ env "FORECASTLE_INSTALLED" | default "true" }}
     force: true


### PR DESCRIPTION
## what
1. [forecastle] update to newest version 1.0.27

## why
1. Adds the ability to override URLs based on annotations: https://github.com/stakater/Forecastle/pull/69/files
2. Adds custom apps: https://github.com/stakater/Forecastle/pull/71

I'm sure other fixes as well, but those are the two i'm interested in trying out.
