### PR TITLE
[forecastle] Upgrade 1.0.25->1.0.27

### DIFF
--- a/releases/forecastle.yaml
+++ b/releases/forecastle.yaml
@@ -4,7 +4,8 @@ repositories:
     # Cannot use release tags, see https://github.com/aslafy-z/helm-git/issues/9
     # url: "git+https://github.com/stakater/Forecastle@deployments/kubernetes/chart?ref=v1.0.22"
     # v1.0.22: url: "git+https://github.com/stakater/Forecastle@deployments/kubernetes/chart?ref=8d6e5cd2dba3ad6c265ae94138c40276425b7634"
-    url: "git+https://github.com/stakater/Forecastle@deployments/kubernetes/chart?ref=8f36b82beaf2a1a42b364a3857bc83638c51e30b"
+    # v1.0.25 url: "git+https://github.com/stakater/Forecastle@deployments/kubernetes/chart?ref=8f36b82beaf2a1a42b364a3857bc83638c51e30b"
+    url: "git+https://github.com/stakater/Forecastle@deployments/kubernetes/chart?ref=ffb5179aa659e0e3cf0ca20e1c8bd94c5fd66a2e"
 
 releases:
 
@@ -19,7 +20,7 @@ releases:
   #   - https://github.com/stakater/Forecastle
   #
   - name: "forecastle"
-    namespace: "kube-system"
+    namespace: '{{ env "FORECASTLE_NAMESPACE" | default "kube-system" }}'
     labels:
       chart: "forecastle"
       repo: "github"
@@ -28,18 +29,26 @@ releases:
       vendor: "stakater"
       default: "false"
     chart: "forecastle/forecastle"
-    version: "v1.0.25"
+    version: "v1.0.27"
     wait: false
     installed: {{ env "FORECASTLE_INSTALLED" | default "true" }}
     force: true
     recreatePods: true
     values:
+      {{- if env "FORECASTLE_CUSTOM_APPS_YAML" }}
+      - {{ env "FORECASTLE_CUSTOM_APPS_YAML" }}
+      {{- end }}
       - forecastle:
           image:
             pullPolicy: "IfNotPresent"
-          namespace: "kube-system"
+          namespace: '{{ env "FORECASTLE_NAMESPACE" | default "kube-system" }}'
           deployment:
+            # Some annotation is required or else we get a bunch of
+            # annotations from the default values.yaml
             annotations: ""
+            replicas: '{{- env "FORECASTLE_REPLICAS" | default "2" -}}'
+            revisionHistoryLimit: '{{- env "FORECASTLE_REVISION_HISTORY_LIMIT" | default "10" -}}'
+
           config:
             # If only running one instance of Forecastle, it is best to leave the instance name blank
             instanceName: {{ env "FORECASTLE_INSTANCE_NAME" }}
@@ -51,6 +60,18 @@ releases:
               matchNames: []
               {{- end }}
             title: {{ env "FORECASTLE_TITLE" | default "Portal" }}
+            ## Add custom apps via FORECASTLE_CUSTOM_APPS_YAML file in this format:
+            # forecastle:
+            #    config:
+            #      customApps:
+            #        - name: Hello
+            #          url: http://helloicon
+            #          icon: http://hello
+            #          group: Test
+            #        - name: world
+            #          url: http://worldicon
+            #          icon: https://world
+            #          group: Test
           service:
             annotations: ""
             expose: "true"

--- a/releases/keycloak-gatekeeper.yaml
+++ b/releases/keycloak-gatekeeper.yaml
@@ -79,6 +79,9 @@ releases:
         forecastle.stakater.com/expose: "true"
         forecastle.stakater.com/appName: "{{ $service.portalName }}"
         {{- end }}
+        {{- if index $service "portalIcon" }}
+        forecastle.stakater.com/icon: "{{ $service.portalIcon }}"
+        {{- end }}
         {{- if index $service "forecastleInstanceName"  }}
         forecastle.stakater.com/instance: "{{ $service.forecastleInstanceName }}"
         {{- end }}

--- a/releases/oidc-ingress.yaml
+++ b/releases/oidc-ingress.yaml
@@ -12,7 +12,9 @@ repositories:
 - name: "forecastle"
   # Cannot use release tags, see https://github.com/aslafy-z/helm-git/issues/9
   # url: "git+https://github.com/stakater/Forecastle@deployments/kubernetes/chart?ref=v1.0.25"
-  url: "git+https://github.com/stakater/Forecastle@deployments/kubernetes/chart?ref=8f36b82beaf2a1a42b364a3857bc83638c51e30b"
+  # v1.0.25 url: "git+https://github.com/stakater/Forecastle@deployments/kubernetes/chart?ref=8f36b82beaf2a1a42b364a3857bc83638c51e30b"
+  # v1.0.27:
+  url: "git+https://github.com/stakater/Forecastle@deployments/kubernetes/chart?ref=ffb5179aa659e0e3cf0ca20e1c8bd94c5fd66a2e"
 
 releases:
 
@@ -93,8 +95,8 @@ releases:
       {{- end }}
     # discoveryURL is the  OIDC provider's base URL, under which you can retrieve ".well-known/openid-configuration"
     discoveryURL: '{{- coalesce (env "OIDC_INGRESS_OIDC_ISSUER_URL") (env "KEYCLOAK_GATEKEEPER_DISCOVERY_URL") (env "KOPS_OIDC_ISSUER_URL") }}'
-    # OIDC_INGRESS_INGRESS_HOST is the hostname of the ingress BEHIND (protected by) oidc-ingress
-    upstreamURL: 'https://{{- env "OIDC_INGRESS_NGINX_HOST" | default "oidc-ingress-nginx-controller.oidc-ingress.svc" }}'
+    # OIDC_INGRESS_NGINX_HOST is the hostname of the ingress BEHIND (protected by) oidc-ingress
+    upstreamURL: '{{- env "OIDC_INGRESS_UPSTREAM_SCHEME" | default "https" -}}://{{- env "OIDC_INGRESS_NGINX_HOST" | default "oidc-ingress-nginx-controller.oidc-ingress.svc" }}'
     skipUpstreamTlsVerify: {{ env "OIDC_INGRESS_SKIP_UPSTREAM_TLS_VERIFY" | default "true" }}
     ClientID: '{{- coalesce (env "OIDC_INGRESS_CLIENT_ID") (env "KOPS_OIDC_CLIENT_ID") "kubernetes" }}'
     ClientSecret: '{{- requiredEnv "OIDC_INGRESS_CLIENT_SECRET" }}'
@@ -109,12 +111,19 @@ releases:
     {{- end }}
     extraArgs:
       - preserve-host=true
+      - enable-token-header=false
+      - enable-authorization-header=false
+      - enable-authorization-cookies=false
       {{- if env "OIDC_INGRESS_PROXY_TIMEOUT" }}
       - upstream-timeout={{- env "OIDC_INGRESS_PROXY_TIMEOUT" -}}s
       - server-read-timeout={{- env "OIDC_INGRESS_PROXY_TIMEOUT" -}}s
       - server-write-timeout={{- env "OIDC_INGRESS_PROXY_TIMEOUT" -}}s
       - upstream-expect-continue-timeout={{- env "OIDC_INGRESS_PROXY_TIMEOUT" -}}s
       - upstream-response-header-timeout={{- env "OIDC_INGRESS_PROXY_TIMEOUT" -}}s
+      {{- end }}
+      {{- if eq (env "OIDC_INGRESS_DEBUG_ENABLED" | default "false") "true" }}
+      - enable-logging=true
+      - verbose
       {{- end }}
     rbac:
       create: {{ env "RBAC_ENABLED" | default "false" }}
@@ -220,7 +229,8 @@ releases:
 ##############################################################################
 #
 # References:
-#   - https://github.com/stakater/Forecastle/tree/v1.0.25/deployments/kubernetes/chart/forecastle
+#   - https://github.com/stakater/Forecastle/tree/v1.0.27/deployments/kubernetes/chart/forecastle
+# v1.0.27  url: "git+https://github.com/stakater/Forecastle@deployments/kubernetes/chart?ref=ffb5179aa659e0e3cf0ca20e1c8bd94c5fd66a2e"
 #   - https://github.com/stakater/Forecastle
 #
 - name: "oidc-ingress-forecastle"
@@ -233,7 +243,7 @@ releases:
     vendor: "stakater"
     default: "false"
   chart: "forecastle/forecastle"
-  version: "v1.0.25"
+  version: "v1.0.27"
   wait: false
   installed: {{ env "OIDC_INGRESS_FORECASTLE_INSTALLED" | default "true" }}
   force: true
@@ -248,6 +258,8 @@ releases:
         deployment:
           # The chart sets lots of annotations by default unless explicitly cleared
           annotations: ""
+          replicas: '{{- env "OIDC_INGRESS_FORECASTLE_REPLICAS" | default "2" -}}'
+          revisionHistoryLimit: '{{- env "OIDC_INGRESS_FORECASTLE_REVISION_HISTORY_LIMIT" | default "10" -}}'
         config:
           # Let the Forecastle instance name reflect the nginx ingress class
           # for simplicity and ease of understanding.
@@ -288,6 +300,7 @@ releases:
         annotations:
           forecastle.stakater.com/appName: "{{ env "OIDC_INGRESS_PORTAL_TITLE" | default "QA Portal" }}"
           forecastle.stakater.com/expose: "true"
+          forecastle.stakater.com/url: 'https://{{- env "OIDC_INGRESS_PORTAL_HOST" -}}'
           {{- if env "FORECASTLE_INSTANCE_NAME" }}
           forecastle.stakater.com/instance: "{{ env "FORECASTLE_INSTANCE_NAME" }}"
           {{- end }}
@@ -296,9 +309,6 @@ releases:
           kubernetes.io/tls-acme: "false"
         name: oidc-ingress-portal
       spec:
-        tls:
-        - hosts:
-          - '{{ env "OIDC_INGRESS_PORTAL_HOST" }}'
         rules:
         - host: '{{ env "OIDC_INGRESS_PORTAL_HOST" }}'
           http:


### PR DESCRIPTION
## what
- [forecastle] Upgrade 1.0.25->1.0.27
- [keycloak-gatekeeper] Upgrade forecastle 1.0.25->1.0.27
- [oidc-ingress] Upgrade forecastle 1.0.25->1.0.27

## why
- Add ability to add arbitrary links to Forecastle portal