### PR TITLE
[nginx-ingress] Update default backend with PDB

### DIFF
--- a/releases/aws-alb-ingress-controller.yaml
+++ b/releases/aws-alb-ingress-controller.yaml
@@ -1,6 +1,6 @@
 repositories:
 # Incubator repo of official helm charts
-- name: "incubator"
+- name: "kubernetes-incubator"
   url: "http://storage.googleapis.com/kubernetes-charts-incubator"
 
 
@@ -23,7 +23,7 @@ releases:
     namespace: "kube-system"
     vendor: "kubernetes"
     default: "false"
-  chart: "incubator/aws-alb-ingress-controller"
+  chart: "kubernetes-incubator/aws-alb-ingress-controller"
   version: "0.1.4"
   wait: true
   installed: {{ env "AWS_ALB_INGRESS_CONTROLLER_INSTALLED" | default "true" }}

--- a/releases/codefresh-account.yaml
+++ b/releases/codefresh-account.yaml
@@ -1,6 +1,6 @@
 repositories:
 # Cloud Posse incubator repo of helm charts
-- name: "cloudposse-incubator-dev"
+- name: "cloudposse-incubator"
   url: "https://charts.cloudposse.com/incubator/"
 
 

--- a/releases/codefresh-backup.yaml
+++ b/releases/codefresh-backup.yaml
@@ -1,6 +1,6 @@
 repositories:
 # Incubator repo of official helm charts
-- name: "incubator"
+- name: "kubernetes-incubator"
   url: "https://kubernetes-charts-incubator.storage.googleapis.com/"
 
 releases:
@@ -13,7 +13,7 @@ releases:
     namespace: "codefresh"
     vendor: "kubernetes-incubator"
     default: "false"
-  chart: "incubator/raw"
+  chart: "kubernetes-incubator/raw"
   version: "0.1.0"
   wait: true
   installed: {{ env "CODEFRESH_BACKUP_ENABLED" | default "true" }}

--- a/releases/codefresh-restore.yaml
+++ b/releases/codefresh-restore.yaml
@@ -1,6 +1,6 @@
 repositories:
 # Incubator repo of official helm charts
-- name: "incubator"
+- name: "kubernetes-incubator"
   url: "https://kubernetes-charts-incubator.storage.googleapis.com/"
 
 releases:
@@ -13,7 +13,7 @@ releases:
     namespace: "codefresh"
     vendor: "kubernetes-incubator"
     default: "false"
-  chart: "incubator/raw"
+  chart: "kubernetes-incubator/raw"
   version: "0.1.0"
   wait: true
   installed: {{ env "CODEFRESH_RESTORE_ENABLED" | default "FALSE" }}

--- a/releases/kibana-elastic-search.yaml
+++ b/releases/kibana-elastic-search.yaml
@@ -1,6 +1,6 @@
 repositories:
 # Incubator repo of official helm charts
-- name: "incubator"
+- name: "kubernetes-incubator"
   url: "https://kubernetes-charts-incubator.storage.googleapis.com/"
 
 releases:
@@ -23,7 +23,7 @@ releases:
     namespace: "kube-system"
     vendor: "kubernetes"
     default: "false"
-  chart: "incubator/raw"
+  chart: "kubernetes-incubator/raw"
   version: "0.1.0"
   wait: true
   installed: {{ env "KIBANA_ELASTICSEARCH_INSTALLED" | default "true" }}

--- a/releases/nginx-ingress.yaml
+++ b/releases/nginx-ingress.yaml
@@ -75,7 +75,7 @@ releases:
 
           serviceMonitor:
             enabled: {{ env "NGINX_INGRESS_METRICS_ENABLED" | default "false" }}
-
+          {{- if eq (env "NGINX_INGRESS_PROMETHEUS_RULE_ENABLED" | default "true") "true" }}
           prometheusRule:
             enabled: {{ env "NGINX_INGRESS_METRICS_ENABLED" | default "false" }}
             rules:
@@ -86,7 +86,7 @@ releases:
                 expr: nginx_ingress_controller_requests > {{ env "NGINX_INGRESS_METRICS_CONTROLLER_ERROR_ALERT" | default "100000" }}
                 labels:
                   severity: warning
-
+          {{- end }}
       ### Regexp used to map
       ### 8080:default/example-tcp-svc:9000,8081:staging/example-tcp-svc:9000
       ### to
@@ -128,7 +128,7 @@ releases:
     vendor: "kubernetes"
     default: "true"
   chart: "cloudposse-incubator/nginx-default-backend"
-  version: "0.3.0"
+  version: "0.4.0"
   wait: true
   installed: {{ env "NGINX_INGRESS_BACKEND_INSTALLED" | default "true" }}
   values:
@@ -137,8 +137,8 @@ releases:
       replicaCount: '{{ env "NGINX_INGRESS_BACKEND_REPLICA_COUNT" | default "2" }}'
       resources:
         limits:
-          cpu: '{{ env "NGINX_INGRESS_DEFAULT_BACKEND_LIMIT_CPU" | default "200m" }}'
-          memory: '{{ env "NGINX_INGRESS_DEFAULT_BACKEND_LIMIT_MEMORY" | default "256Mi" }}'
+          cpu: '{{ env "NGINX_INGRESS_DEFAULT_BACKEND_LIMIT_CPU" | default "50m" }}'
+          memory: '{{ env "NGINX_INGRESS_DEFAULT_BACKEND_LIMIT_MEMORY" | default "24Mi" }}'
         requests:
           cpu: '{{ env "NGINX_INGRESS_DEFAULT_BACKEND_REQUEST_CPU" | default "1m" }}'
           memory: '{{ env "NGINX_INGRESS_DEFAULT_BACKEND_REQUEST_MEMORY" | default "8Mi" }}'
@@ -172,7 +172,6 @@ releases:
 #   - https://grafana.com/grafana
 #   - https://github.com/helm/charts/tree/master/stable/grafana
 #
-{{ if eq ( env "NGINX_INGRESS_METRICS_ENABLED" | default "false" ) "true" }}
 - name: "ingress-monitoring"
   namespace: "monitoring"
   labels:
@@ -184,7 +183,8 @@ releases:
   chart: "cloudposse-incubator/monochart"
   version: "0.10.0"
   wait: true
-  installed: {{ env "NGINX_INGRESS_METRICS_INSTALLED" | default "true" }}
+  # Unfortunately, you cannot split a go template statement across multiple lines, so this has to be one big long line
+  installed: {{ and (eq ( env "NGINX_INGRESS_METRICS_ENABLED" | default "false" ) "true") (eq ( env "NGINX_INGRESS_GRAFANA_DASHBOARD_ENABLED" | default "true" ) "true" ) }}
   values:
   - configMaps:
       dashboards:
@@ -194,4 +194,3 @@ releases:
         files:
           nginx-ingress.json: |
 {{ exec "curl" (list "-fsSL" (print "https://raw.githubusercontent.com/cloudposse/grafana-dashboards/" (env "GRAFANA_DASHBOARDS_VERSION" | default "1.0") "/nginx-ingress/nginx.json")) | indent 12 }}
-{{ end }}


### PR DESCRIPTION
## what
1. [nginx-ingress] Update default backend with PDB, make prometheus rules and grafana dashboard optional
1. Normalize repo nicknames

## why
1. Work better with autoscaler, allow users to install their own prometheus rules and grafana dashboards
1. Helm treats 1 repo with 2 nicknames as 2 repos, slowing things down.
