### PR TITLE
Minor tweaks

### DIFF
--- a/releases/aws-alb-ingress-controller.yaml
+++ b/releases/aws-alb-ingress-controller.yaml
@@ -1,7 +1,7 @@
 repositories:
 # Incubator repo of official helm charts
 - name: "kubernetes-incubator"
-  url: "https://kubernetes-charts.storage.googleapis.com"
+  url: "https://kubernetes-charts-incubator.storage.googleapis.com"
 
 
 releases:

--- a/releases/aws-alb-ingress-controller.yaml
+++ b/releases/aws-alb-ingress-controller.yaml
@@ -1,7 +1,7 @@
 repositories:
 # Incubator repo of official helm charts
 - name: "kubernetes-incubator"
-  url: "http://storage.googleapis.com/kubernetes-charts-incubator"
+  url: "https://kubernetes-charts.storage.googleapis.com"
 
 
 releases:

--- a/releases/keycloak-gatekeeper.yaml
+++ b/releases/keycloak-gatekeeper.yaml
@@ -82,6 +82,9 @@ releases:
         {{- if index $service "portalIcon" }}
         forecastle.stakater.com/icon: "{{ $service.portalIcon }}"
         {{- end }}
+        {{- if index $service "portalURL" }}
+        forecastle.stakater.com/url: "{{ $service.portalURL }}"
+        {{- end }}
         {{- if index $service "forecastleInstanceName"  }}
         forecastle.stakater.com/instance: "{{ $service.forecastleInstanceName }}"
         {{- end }}

--- a/releases/keycloak.yaml
+++ b/releases/keycloak.yaml
@@ -69,12 +69,12 @@ releases:
           kubernetes.io/ingress.class: nginx
           kubernetes.io/tls-acme: "true"
           ingress.kubernetes.io/affinity: cookie
-          nginx.ingress.kubernetes.io/app-root: /auth/admin/
           external-dns.alpha.kubernetes.io/target: '{{ requiredEnv "NGINX_INGRESS_HOSTNAME" }}'
           external-dns.alpha.kubernetes.io/ttl: "60"
           {{- if eq (env "KEYCLOAK_FORECASTLE_EXPOSE" | default "true") "true" }}
           forecastle.stakater.com/expose: "true"
           forecastle.stakater.com/appName: "Keycloak"
+          forecastle.stakater.com/url: 'https://{{- env "KEYCLOAK_INGRESS_HOSTS" -}}/auth/admin/'
           {{- if coalesce (env "KEYCLOAK_FORECASTLE_INSTANCE_NAME") (env "FORECASTLE_INSTANCE_NAME") }}
           forecastle.stakater.com/instance: '{{ coalesce (env "KEYCLOAK_FORECASTLE_INSTANCE_NAME") (env "FORECASTLE_INSTANCE_NAME") }}'
           {{- end }}


### PR DESCRIPTION
## what
1. [aws-alb-ingress-controller] use modern version of helm repo URL
1. [keycloak-gatekeeper] Add option for custom URL
1. [keycloak] Use custom URL rather than app root for Forecastle

## why
1. Helm requires consistency of repo nickname and repo URL
1. Requested feature
1. Leaves root path available. 
