### PR TITLE
[oidc-ingress] Fix custom errors

### DIFF
--- a/releases/oidc-ingress.yaml
+++ b/releases/oidc-ingress.yaml
@@ -78,6 +78,9 @@ releases:
       annotations:
         kubernetes.io/ingress.class: nginx
         nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
+        # Disable custom errors on the ingress in front of the OIDC ingress,
+        # because otherwise errors behind the OIDC ingress would not get through
+        nginx.ingress.kubernetes.io/custom-http-errors: "418,599"
         {{- if env "OIDC_INGRESS_PROXY_TIMEOUT" }}
         nginx.ingress.kubernetes.io/proxy-connect-timeout: "{{- env "OIDC_INGRESS_PROXY_TIMEOUT" -}}"
         nginx.ingress.kubernetes.io/proxy-read-timeout: "{{- env "OIDC_INGRESS_PROXY_TIMEOUT" -}}"


### PR DESCRIPTION
## what
1. [oidc-ingress] Disable custom errors on the ingress in front of the OIDC ingress for the OIDC ingress and everything behind it
## why
1. If the ingress in front of the OIDC ingress is showing custom errors, then any error pages generated behind the OIDC ingress will not be shown