### PR TITLE
Cluster autoscaler compatibility

### DIFF
--- a/releases/dashboard.yaml
+++ b/releases/dashboard.yaml
@@ -16,7 +16,7 @@ releases:
 #   - https://github.com/kubernetes/charts/tree/master/stable/kubernetes-dashboard
 #
 - name: "kubernetes-dashboard"
-  namespace: "kube-system"
+  namespace: '{{- env "KUBERNETES_DASHBOARD_NAMESPACE" | default "kube-system" -}}'
   labels:
     chart: "kubernetes-dashboard"
     repo: "stable"

--- a/releases/external-dns.yaml
+++ b/releases/external-dns.yaml
@@ -44,11 +44,12 @@ releases:
         email: '{{ env "EXTERNAL_DNS_CLOUDFLARE_EMAIL" }}'
 {{ end }}
 
-{{ if env "EXTERNAL_DNS_PROVIDER" | default "aws" | eq "aws" }}
       podAnnotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+        {{- if env "EXTERNAL_DNS_PROVIDER" | default "aws" | eq "aws" }}
         ### Required: EXTERNAL_DNS_IAM_ROLE; e.g. cp-staging-external-dns
         iam.amazonaws.com/role: '{{ env "EXTERNAL_DNS_IAM_ROLE" }}'
-{{ end }}
+        {{- end }}
       resources:
         limits:
           cpu: '{{ env "EXTERNAL_DNS_LIMIT_CPU" | default "200m" }}'

--- a/releases/prometheus-operator.yaml
+++ b/releases/prometheus-operator.yaml
@@ -207,6 +207,9 @@ releases:
           replicas: 1
           retention: {{ env "PROMETHEUS_OPERATOR_PROMETHEUS_RETENTION_PERIOD" | default "45d" }}
           logLevel: "warn"
+          podMetadata:
+            annotations:
+              "cluster-autoscaler.kubernetes.io/safe-to-evict": "true"
           scrapeInterval: ""
           evaluationInterval: ""
           ## If true, a nil or {} value for prometheus.prometheusSpec.ruleSelector will cause the

--- a/releases/teleport-ent-auth.yaml
+++ b/releases/teleport-ent-auth.yaml
@@ -30,8 +30,9 @@ releases:
     namespace: "teleport"
     vendor: "teleport"
     default: "false"
-  chart: "cloudposse-incubator/teleport-ent-auth"
-  version: "0.1.1"
+  # chart: "cloudposse-incubator/teleport-ent-auth"
+  chart: /Users/jgro/CP_dev/charts/incubator/teleport-ent-auth
+  version: "0.2.0"
   wait: true
   # atomic is not widely supported yet, but when it is, we should use it
   # atomic: true
@@ -52,11 +53,12 @@ releases:
   - nameOverride: "teleport-auth"
     image:
       repository: quay.io/gravitational/teleport-ent
-      tag: '{{ env "TELEPORT_VERSION" | default "3.2.2" }}'
+      tag: '{{ env "TELEPORT_VERSION" | default "4.0.9" }}'
       pullPolicy: "IfNotPresent"
       # command: ["/usr/bin/dumb-init"]
       # args:  ["teleport", "start", "--insecure-no-tls", "-c", "/etc/teleport/teleport.yaml"]
     replicaCount: {{ env "TELEPORT_AUTH_REPLICA_COUNT" | default 1 }}
+    maxUnavailable: {{ env "TELEPORT_MAX_UNAVAILABLE" | default 1 }}
     rbac:
       create: false
     serviceAccount:

--- a/releases/teleport-ent-proxy.yaml
+++ b/releases/teleport-ent-proxy.yaml
@@ -28,8 +28,9 @@ releases:
     namespace: "teleport"
     vendor: "teleport"
     default: "false"
-  chart: "cloudposse-incubator/teleport-ent-proxy"
-  version: "0.3.0"
+  # chart: "cloudposse-incubator/teleport-ent-proxy"
+  chart: /Users/jgro/CP_dev/charts/incubator/teleport-ent-proxy
+  version: "0.4.0"
   wait: true
   force: true
   installed: {{ env "TELEPORT_PROXY_INSTALLED" | default "true" }}
@@ -42,12 +43,16 @@ releases:
     nameOverride: "teleport-proxy"
     image:
       repository: quay.io/gravitational/teleport-ent
-      tag: '{{ env "TELEPORT_VERSION" | default "3.2.2" }}'
+      tag: '{{ env "TELEPORT_VERSION" | default "4.0.9" }}'
       pullPolicy: "IfNotPresent"
       # command: ["/usr/bin/dumb-init"]
       # args:  ["teleport", "start", "--insecure-no-tls", "-c", "/etc/teleport/teleport.yaml"]
+    podAnnotations:
+      cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
 
     replicaCount: {{ env "TELEPORT_PROXY_REPLICA_COUNT" | default 2 }}
+    maxUnavailable: {{ env "TELEPORT_PROXY_MAX_UNAVAILABLE" | default "75%" }}
+
     # RBAC and serviceAccount are required for proxy for Kubernetes integration starting with Teleport 3.2.0
     rbac:
       create: true


### PR DESCRIPTION
## what
- [teleport-ent-auth] Add PodDisruptionBudget
- [teleport-ent-proyx] Add PodDisruptionBudget and "safe-to-evict" annotation
- [dashboard] Make installation namespace configurable
- [external-dns] Add "safe-to-evict" annotation
- [prometheus-operator] Add "safe-to-evict" annotation to Prometheus

## why
- Make pods movable to better support autoscaling the cluster