### PR TITLE
[cluster-autoscaler] Update to 1.14

### DIFF
--- a/releases/cluster-autoscaler.yaml
+++ b/releases/cluster-autoscaler.yaml
@@ -23,13 +23,13 @@ releases:
     namespace: "kube-system"
     vendor: "kubernetes"
   chart: "stable/cluster-autoscaler"
-  version: "3.2.0"
+  version: "6.0.0"
   wait: true
   installed: {{ env "CLUSTER_AUTOSCALER_INSTALLED" | default "true" }}
   values:
     - image:
         ### Optional: CLUSTER_AUTOSCALER_IMAGE_TAG;
-        tag: '{{ env "CLUSTER_AUTOSCALER_IMAGE_TAG" | default "v1.13.6" }}'
+        tag: '{{ env "CLUSTER_AUTOSCALER_IMAGE_TAG" | default "v1.14.5" }}'
       autoDiscovery:
         ### Required: KOPS_CLUSTER_NAME; e.g. cluster.k8s.local
         clusterName: '{{ env "KOPS_CLUSTER_NAME" }}'


### PR DESCRIPTION
## what
1. [cluster-autoscaler] Update `cluster-autoscaler` version to the latest

## why
1. Get the latest fixes and version best fit k8s 1.14
