### PR TITLE
update kubecost to v. 1.46.6

### DIFF
--- a/releases/kubecost.yaml
+++ b/releases/kubecost.yaml
@@ -27,7 +27,7 @@ releases:
       vendor: "kubecost"
       default: "false"
     chart: "kubecost/cost-analyzer"
-    version: "v1.37.0"
+    version: "v1.46.6"
     wait: true
     installed: {{ env "KUBECOST_INSTALLED" | default "true" }}
     values:


### PR DESCRIPTION
## what
1. [kubecost] update to version 1.46.6

## why
1. There are bugfixes, including [fix PV logging, gauge jittering](https://github.com/kubecost/cost-model/commit/3a874280cdb22b4fd2e5afbcf0bc163af1f20e50) commit to avoid lot's of log records