### PR TITLE
Kiam alerts

### DIFF
--- a/releases/elasticsearch-exporter.yaml
+++ b/releases/elasticsearch-exporter.yaml
@@ -30,13 +30,6 @@ releases:
           uri: {{ env "ELASTICSEARCH_EXPORTER_ELASTICSEARCH_URI" }}
         serviceMonitor:
           enabled: true
-        resources:
-          limits:
-            cpu: '{{ env "ELASTICSEARCH_EXPORTER_LIMIT_CPU" | default "20m" }}'
-            memory: '{{ env "ELASTICSEARCH_EXPORTER_LIMIT_MEMORY" | default "24Mi" }}'
-          requests:
-            cpu: '{{ env "ELASTICSEARCH_EXPORTER_REQUEST_CPU" | default "5m" }}'
-            memory: '{{ env "ELASTICSEARCH_EXPORTER_REQUEST_MEMORY" | default "12Mi" }}'
         prometheusRule:
           # These rules are designed for elasticsearch-exporter running against AWS hosted Elasticsearch
           enabled: {{ env "ELASTICSEARCH_EXPORTER_PROMETHEUS_RULES_INSTALLED" | default "true" }}

--- a/releases/kiam.yaml
+++ b/releases/kiam.yaml
@@ -174,7 +174,7 @@ releases:
           # pod's assigned IAM role and corresponding credentials. Here we return to essentially full
           # access to the metadata, while also doing a sanity check on the URL and giving you a template
           # in case you want to restrict access to one section of data.
-          whitelist-route-regexp: '^\/(latest\/(meta-data|user-data|dynamic)|$)'
+          whitelist-route-regexp: '^/(latest/(meta-data|user-data|dynamic)|$)'
       server:
         gatewayTimeoutCreation: "5s"
         nodeSelector:

--- a/releases/kiam.yaml
+++ b/releases/kiam.yaml
@@ -240,7 +240,7 @@ releases:
         endpoints:
           - port: "metrics"
             interavl: 15s
-
+{{ $prometheusBaseUrl := env "PROMETHEUS_PROMETHEUS_EXTERNAL_URL" | default (print "https://api." (env "KOPS_CLUSTER_NAME") "/api/v1/namespaces/monitoring/services/prometheus-operator-prometheus:") }}
     prometheusRules:
       default:
         labels:
@@ -251,12 +251,16 @@ releases:
             - alert: kiam_sts_issuing_errors_total
               annotations:
                 message: There are errors issuing credentials
+                description: Number of errors issuing credentials
+                runbook_url: {{ $prometheusBaseUrl }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"error%20requesting%20credentials"'),sort:!('@timestamp',desc))
               expr: {{ env "KIAM_ALERT_STS_ISSUING_ERROR_TOTAL_WARNING_EXPR" | default "increase(kiam_sts_issuing_errors_total[1m]) >= 1" }}
               labels:
                 severity: warning
             - alert: kiam_sts_issuing_errors_total
               annotations:
                 message: There are errors issuing credentials
+                description: Number of errors issuing credentials
+                runbook_url: {{ $prometheusBaseUrl }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"error%20requesting%20credentials"'),sort:!('@timestamp',desc))
               expr: {{ env "KIAM_ALERT_STS_ISSUING_ERROR_TOTAL_CRITICAL_EXPR" | default "increase(kiam_sts_issuing_errors_total[5m]) >= 1" }}
               labels:
                 severity: critical
@@ -264,12 +268,67 @@ releases:
             - alert: kiam_metadata_find_role_errors_total
               annotations:
                 message: Pod try to use non-exiting role
+                description: Number of errors finding the role for a pod
+                runbook_url: {{ $prometheusBaseUrl }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'%22error%20finding%20role%20for%20pod%22'),sort:!('@timestamp',desc))
               expr: {{ env "KIAM_ALERT_METADATA_FIND_ROLE_ERRORS_TOTAL_WARNING_EXPR" | default "increase(kiam_metadata_find_role_errors_total[1m]) >= 1" }}
               labels:
                 severity: warning
             - alert: kiam_metadata_find_role_errors_total
               annotations:
                 message: Pod try to use non-exiting role
+                description: Number of errors finding the role for a pod
+                runbook_url: {{ $prometheusBaseUrl }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'%22error%20finding%20role%20for%20pod%22'),sort:!('@timestamp',desc))
               expr: {{ env "KIAM_ALERT_METADATA_FIND_ROLE_ERRORS_TOTAL_CRITICAL_EXPR" | default "increase(kiam_metadata_find_role_errors_total[5m]) >= 1" }}
+              labels:
+                severity: critical
+
+            - alert: kiam_metadata_empty_role_total
+              annotations:
+                message: Pod try to use empty role
+                description: Number of empty roles returned
+                runbook_url: {{ $prometheusBaseUrl }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"empty%20role"'),sort:!('@timestamp',desc))
+              expr: {{ env "KIAM_ALERT_METADATA_EMPTY_ROLE_TOTAL_WARNING_EXPR" | default "increase(kiam_metadata_empty_role_total[1m]) >= 1" }}
+              labels:
+                severity: warning
+            - alert: kiam_metadata_empty_role_total
+              annotations:
+                message: Pod try to use empty role
+                description: Number of empty roles returned
+                runbook_url: {{ $prometheusBaseUrl }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"empty%20role"'),sort:!('@timestamp',desc))
+              expr: {{ env "KIAM_ALERT_METADATA_EMPTY_ROLE_TOTAL_CRITICAL_EXPR" | default "increase(kiam_metadata_empty_role_total[5m]) >= 1" }}
+              labels:
+                severity: critical
+
+            - alert: kiam_metadata_credential_fetch_errors_total
+              annotations:
+                message: Error fetch aws credentials
+                description: Number of errors fetching the credentials for a pod
+                runbook_url: {{ $prometheusBaseUrl }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"error%20fetching%20credentials"'),sort:!('@timestamp',desc))
+              expr: {{ env "KIAM_ALERT_METADATA_CREDENTIAL_FETCH_ERRORS_TOTAL_WARNING_EXPR" | default "increase(kiam_metadata_credential_fetch_errors_total[1m]) >= 1" }}
+              labels:
+                severity: warning
+            - alert: kiam_metadata_credential_fetch_errors_total
+              annotations:
+                message: Error fetch aws credentials
+                description: Number of errors fetching the credentials for a pod
+                runbook_url: {{ $prometheusBaseUrl }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"error%20fetching%20credentials"'),sort:!('@timestamp',desc))
+              expr: {{ env "KIAM_ALERT_METADATA_CREDENTIAL_FETCH_ERRORS_TOTAL_CRITICAL_EXPR" | default "increase(kiam_metadata_credential_fetch_errors_total[5m]) >= 1" }}
+              labels:
+                severity: critical
+
+            - alert: kiam_metadata_proxy_requests_blocked_total
+              annotations:
+                message: Assuming role blocked because of namespace annotations `iam.amazonaws.com/permitted`
+                description: Number of access requests to the proxy handler that were blocked by the regexp
+                runbook_url: {{ $prometheusBaseUrl }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"request%20blocked%20by%20whitelist-route-regexp"'),sort:!('@timestamp',desc))
+              expr: {{ env "KIAM_ALERT_METADATA_PROXY_REQUESTS_BLOCKED_TOTAL_WARNING_EXPR" | default "increase(kiam_metadata_proxy_requests_blocked_total[1m]) >= 1" }}
+              labels:
+                severity: warning
+            - alert: kiam_metadata_proxy_requests_blocked_total
+              annotations:
+                message: Assuming role blocked because of namespace annotations `iam.amazonaws.com/permitted`
+                description: Number of access requests to the proxy handler that were blocked by the regexp
+                runbook_url: {{ $prometheusBaseUrl }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"request%20blocked%20by%20whitelist-route-regexp"'),sort:!('@timestamp',desc))
+              expr: {{ env "KIAM_ALERT_METADATA_PROXY_REQUESTS_BLOCKED_TOTAL_CRITICAL_EXPR" | default "increase(kiam_metadata_proxy_requests_blocked_total[5m]) >= 1" }}
               labels:
                 severity: critical

--- a/releases/kiam.yaml
+++ b/releases/kiam.yaml
@@ -240,7 +240,7 @@ releases:
         endpoints:
           - port: "metrics"
             interavl: 15s
-{{ $prometheusBaseUrl := env "PROMETHEUS_PROMETHEUS_EXTERNAL_URL" | default (print "https://api." (env "KOPS_CLUSTER_NAME") "/api/v1/namespaces/monitoring/services/prometheus-operator-prometheus:") }}
+
     prometheusRules:
       default:
         labels:
@@ -252,7 +252,7 @@ releases:
               annotations:
                 message: There are errors issuing credentials
                 description: Number of errors issuing credentials
-                logs: {{ $prometheusBaseUrl }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"error%20requesting%20credentials"'),sort:!('@timestamp',desc))
+                logs: {{ env "KUBANA_EXTERNAL_URL" }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"error%20requesting%20credentials"'),sort:!('@timestamp',desc))
               expr: {{ env "KIAM_ALERT_STS_ISSUING_ERROR_TOTAL_WARNING_EXPR" | default "increase(kiam_sts_issuing_errors_total[1m]) >= 1" }}
               labels:
                 severity: warning
@@ -260,7 +260,7 @@ releases:
               annotations:
                 message: There are errors issuing credentials
                 description: Number of errors issuing credentials
-                logs: {{ $prometheusBaseUrl }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"error%20requesting%20credentials"'),sort:!('@timestamp',desc))
+                logs: {{ env "KUBANA_EXTERNAL_URL" }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"error%20requesting%20credentials"'),sort:!('@timestamp',desc))
               expr: {{ env "KIAM_ALERT_STS_ISSUING_ERROR_TOTAL_CRITICAL_EXPR" | default "increase(kiam_sts_issuing_errors_total[5m]) >= 1" }}
               labels:
                 severity: critical
@@ -269,7 +269,7 @@ releases:
               annotations:
                 message: Pod try to use non-exiting role
                 description: Number of errors finding the role for a pod
-                logs: {{ $prometheusBaseUrl }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'%22error%20finding%20role%20for%20pod%22'),sort:!('@timestamp',desc))
+                logs: {{ env "KUBANA_EXTERNAL_URL" }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'%22error%20finding%20role%20for%20pod%22'),sort:!('@timestamp',desc))
               expr: {{ env "KIAM_ALERT_METADATA_FIND_ROLE_ERRORS_TOTAL_WARNING_EXPR" | default "increase(kiam_metadata_find_role_errors_total[1m]) >= 1" }}
               labels:
                 severity: warning
@@ -277,7 +277,7 @@ releases:
               annotations:
                 message: Pod try to use non-exiting role
                 description: Number of errors finding the role for a pod
-                logs: {{ $prometheusBaseUrl }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'%22error%20finding%20role%20for%20pod%22'),sort:!('@timestamp',desc))
+                logs: {{ env "KUBANA_EXTERNAL_URL" }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'%22error%20finding%20role%20for%20pod%22'),sort:!('@timestamp',desc))
               expr: {{ env "KIAM_ALERT_METADATA_FIND_ROLE_ERRORS_TOTAL_CRITICAL_EXPR" | default "increase(kiam_metadata_find_role_errors_total[5m]) >= 1" }}
               labels:
                 severity: critical
@@ -286,7 +286,7 @@ releases:
               annotations:
                 message: Pod try to use empty role
                 description: Number of empty roles returned
-                logs: {{ $prometheusBaseUrl }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"empty%20role"'),sort:!('@timestamp',desc))
+                logs: {{ env "KUBANA_EXTERNAL_URL" }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"empty%20role"'),sort:!('@timestamp',desc))
               expr: {{ env "KIAM_ALERT_METADATA_EMPTY_ROLE_TOTAL_WARNING_EXPR" | default "increase(kiam_metadata_empty_role_total[1m]) >= 1" }}
               labels:
                 severity: warning
@@ -294,7 +294,7 @@ releases:
               annotations:
                 message: Pod try to use empty role
                 description: Number of empty roles returned
-                logs: {{ $prometheusBaseUrl }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"empty%20role"'),sort:!('@timestamp',desc))
+                logs: {{ env "KUBANA_EXTERNAL_URL" }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"empty%20role"'),sort:!('@timestamp',desc))
               expr: {{ env "KIAM_ALERT_METADATA_EMPTY_ROLE_TOTAL_CRITICAL_EXPR" | default "increase(kiam_metadata_empty_role_total[5m]) >= 1" }}
               labels:
                 severity: critical
@@ -303,7 +303,7 @@ releases:
               annotations:
                 message: Error fetch aws credentials
                 description: Number of errors fetching the credentials for a pod
-                logs: {{ $prometheusBaseUrl }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"error%20fetching%20credentials"'),sort:!('@timestamp',desc))
+                logs: {{ env "KUBANA_EXTERNAL_URL" }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"error%20fetching%20credentials"'),sort:!('@timestamp',desc))
               expr: {{ env "KIAM_ALERT_METADATA_CREDENTIAL_FETCH_ERRORS_TOTAL_WARNING_EXPR" | default "increase(kiam_metadata_credential_fetch_errors_total[1m]) >= 1" }}
               labels:
                 severity: warning
@@ -311,7 +311,7 @@ releases:
               annotations:
                 message: Error fetch aws credentials
                 description: Number of errors fetching the credentials for a pod
-                logs: {{ $prometheusBaseUrl }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"error%20fetching%20credentials"'),sort:!('@timestamp',desc))
+                logs: {{ env "KUBANA_EXTERNAL_URL" }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"error%20fetching%20credentials"'),sort:!('@timestamp',desc))
               expr: {{ env "KIAM_ALERT_METADATA_CREDENTIAL_FETCH_ERRORS_TOTAL_CRITICAL_EXPR" | default "increase(kiam_metadata_credential_fetch_errors_total[5m]) >= 1" }}
               labels:
                 severity: critical
@@ -320,7 +320,7 @@ releases:
               annotations:
                 message: Assuming role blocked because of namespace annotations `iam.amazonaws.com/permitted`
                 description: Number of access requests to the proxy handler that were blocked by the regexp
-                logs: {{ $prometheusBaseUrl }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"request%20blocked%20by%20whitelist-route-regexp"'),sort:!('@timestamp',desc))
+                logs: {{ env "KUBANA_EXTERNAL_URL" }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"request%20blocked%20by%20whitelist-route-regexp"'),sort:!('@timestamp',desc))
               expr: {{ env "KIAM_ALERT_METADATA_PROXY_REQUESTS_BLOCKED_TOTAL_WARNING_EXPR" | default "increase(kiam_metadata_proxy_requests_blocked_total[1m]) >= 1" }}
               labels:
                 severity: warning
@@ -328,7 +328,7 @@ releases:
               annotations:
                 message: Assuming role blocked because of namespace annotations `iam.amazonaws.com/permitted`
                 description: Number of access requests to the proxy handler that were blocked by the regexp
-                logs: {{ $prometheusBaseUrl }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"request%20blocked%20by%20whitelist-route-regexp"'),sort:!('@timestamp',desc))
+                logs: {{ env "KUBANA_EXTERNAL_URL" }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"request%20blocked%20by%20whitelist-route-regexp"'),sort:!('@timestamp',desc))
               expr: {{ env "KIAM_ALERT_METADATA_PROXY_REQUESTS_BLOCKED_TOTAL_CRITICAL_EXPR" | default "increase(kiam_metadata_proxy_requests_blocked_total[5m]) >= 1" }}
               labels:
                 severity: critical

--- a/releases/kiam.yaml
+++ b/releases/kiam.yaml
@@ -174,7 +174,7 @@ releases:
           # pod's assigned IAM role and corresponding credentials. Here we return to essentially full
           # access to the metadata, while also doing a sanity check on the URL and giving you a template
           # in case you want to restrict access to one section of data.
-          whitelist-route-regexp: '.*'
+          whitelist-route-regexp: '^\/(latest\/(meta-data|user-data|dynamic)|$)'
       server:
         gatewayTimeoutCreation: "5s"
         nodeSelector:

--- a/releases/kiam.yaml
+++ b/releases/kiam.yaml
@@ -252,7 +252,7 @@ releases:
               annotations:
                 message: There are errors issuing credentials
                 description: Number of errors issuing credentials
-                runbook_url: {{ $prometheusBaseUrl }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"error%20requesting%20credentials"'),sort:!('@timestamp',desc))
+                logs: <a href="{{ $prometheusBaseUrl }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"error%20requesting%20credentials"'),sort:!('@timestamp',desc))">Check logs</a>
               expr: {{ env "KIAM_ALERT_STS_ISSUING_ERROR_TOTAL_WARNING_EXPR" | default "increase(kiam_sts_issuing_errors_total[1m]) >= 1" }}
               labels:
                 severity: warning
@@ -260,7 +260,7 @@ releases:
               annotations:
                 message: There are errors issuing credentials
                 description: Number of errors issuing credentials
-                runbook_url: {{ $prometheusBaseUrl }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"error%20requesting%20credentials"'),sort:!('@timestamp',desc))
+                logs: <a href="{{ $prometheusBaseUrl }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"error%20requesting%20credentials"'),sort:!('@timestamp',desc))">Check logs</a>
               expr: {{ env "KIAM_ALERT_STS_ISSUING_ERROR_TOTAL_CRITICAL_EXPR" | default "increase(kiam_sts_issuing_errors_total[5m]) >= 1" }}
               labels:
                 severity: critical
@@ -269,7 +269,7 @@ releases:
               annotations:
                 message: Pod try to use non-exiting role
                 description: Number of errors finding the role for a pod
-                runbook_url: {{ $prometheusBaseUrl }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'%22error%20finding%20role%20for%20pod%22'),sort:!('@timestamp',desc))
+                logs: <a href="{{ $prometheusBaseUrl }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'%22error%20finding%20role%20for%20pod%22'),sort:!('@timestamp',desc))">Check logs</a>
               expr: {{ env "KIAM_ALERT_METADATA_FIND_ROLE_ERRORS_TOTAL_WARNING_EXPR" | default "increase(kiam_metadata_find_role_errors_total[1m]) >= 1" }}
               labels:
                 severity: warning
@@ -277,7 +277,7 @@ releases:
               annotations:
                 message: Pod try to use non-exiting role
                 description: Number of errors finding the role for a pod
-                runbook_url: {{ $prometheusBaseUrl }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'%22error%20finding%20role%20for%20pod%22'),sort:!('@timestamp',desc))
+                logs: <a href="{{ $prometheusBaseUrl }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'%22error%20finding%20role%20for%20pod%22'),sort:!('@timestamp',desc))">Check logs</a>
               expr: {{ env "KIAM_ALERT_METADATA_FIND_ROLE_ERRORS_TOTAL_CRITICAL_EXPR" | default "increase(kiam_metadata_find_role_errors_total[5m]) >= 1" }}
               labels:
                 severity: critical
@@ -286,7 +286,7 @@ releases:
               annotations:
                 message: Pod try to use empty role
                 description: Number of empty roles returned
-                runbook_url: {{ $prometheusBaseUrl }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"empty%20role"'),sort:!('@timestamp',desc))
+                logs: <a href="{{ $prometheusBaseUrl }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"empty%20role"'),sort:!('@timestamp',desc))">Check logs</a>
               expr: {{ env "KIAM_ALERT_METADATA_EMPTY_ROLE_TOTAL_WARNING_EXPR" | default "increase(kiam_metadata_empty_role_total[1m]) >= 1" }}
               labels:
                 severity: warning
@@ -294,7 +294,7 @@ releases:
               annotations:
                 message: Pod try to use empty role
                 description: Number of empty roles returned
-                runbook_url: {{ $prometheusBaseUrl }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"empty%20role"'),sort:!('@timestamp',desc))
+                logs: <a href="{{ $prometheusBaseUrl }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"empty%20role"'),sort:!('@timestamp',desc))">Check logs</a>
               expr: {{ env "KIAM_ALERT_METADATA_EMPTY_ROLE_TOTAL_CRITICAL_EXPR" | default "increase(kiam_metadata_empty_role_total[5m]) >= 1" }}
               labels:
                 severity: critical
@@ -303,7 +303,7 @@ releases:
               annotations:
                 message: Error fetch aws credentials
                 description: Number of errors fetching the credentials for a pod
-                runbook_url: {{ $prometheusBaseUrl }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"error%20fetching%20credentials"'),sort:!('@timestamp',desc))
+                runbook_url: <a href="{{ $prometheusBaseUrl }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"error%20fetching%20credentials"'),sort:!('@timestamp',desc))">Check logs</a>
               expr: {{ env "KIAM_ALERT_METADATA_CREDENTIAL_FETCH_ERRORS_TOTAL_WARNING_EXPR" | default "increase(kiam_metadata_credential_fetch_errors_total[1m]) >= 1" }}
               labels:
                 severity: warning
@@ -311,7 +311,7 @@ releases:
               annotations:
                 message: Error fetch aws credentials
                 description: Number of errors fetching the credentials for a pod
-                runbook_url: {{ $prometheusBaseUrl }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"error%20fetching%20credentials"'),sort:!('@timestamp',desc))
+                runbook_url: <a href="{{ $prometheusBaseUrl }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"error%20fetching%20credentials"'),sort:!('@timestamp',desc))">Check logs</a>
               expr: {{ env "KIAM_ALERT_METADATA_CREDENTIAL_FETCH_ERRORS_TOTAL_CRITICAL_EXPR" | default "increase(kiam_metadata_credential_fetch_errors_total[5m]) >= 1" }}
               labels:
                 severity: critical
@@ -320,7 +320,7 @@ releases:
               annotations:
                 message: Assuming role blocked because of namespace annotations `iam.amazonaws.com/permitted`
                 description: Number of access requests to the proxy handler that were blocked by the regexp
-                runbook_url: {{ $prometheusBaseUrl }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"request%20blocked%20by%20whitelist-route-regexp"'),sort:!('@timestamp',desc))
+                runbook_url: <a href="{{ $prometheusBaseUrl }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"request%20blocked%20by%20whitelist-route-regexp"'),sort:!('@timestamp',desc))">Check logs</a>
               expr: {{ env "KIAM_ALERT_METADATA_PROXY_REQUESTS_BLOCKED_TOTAL_WARNING_EXPR" | default "increase(kiam_metadata_proxy_requests_blocked_total[1m]) >= 1" }}
               labels:
                 severity: warning
@@ -328,7 +328,7 @@ releases:
               annotations:
                 message: Assuming role blocked because of namespace annotations `iam.amazonaws.com/permitted`
                 description: Number of access requests to the proxy handler that were blocked by the regexp
-                runbook_url: {{ $prometheusBaseUrl }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"request%20blocked%20by%20whitelist-route-regexp"'),sort:!('@timestamp',desc))
+                runbook_url: <a href="{{ $prometheusBaseUrl }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"request%20blocked%20by%20whitelist-route-regexp"'),sort:!('@timestamp',desc))">Check logs</a>
               expr: {{ env "KIAM_ALERT_METADATA_PROXY_REQUESTS_BLOCKED_TOTAL_CRITICAL_EXPR" | default "increase(kiam_metadata_proxy_requests_blocked_total[5m]) >= 1" }}
               labels:
                 severity: critical

--- a/releases/kiam.yaml
+++ b/releases/kiam.yaml
@@ -211,16 +211,63 @@ releases:
   installed: {{ and (eq ( env "KIAM_PROMETHEUS_INSTALLED" | default "false" ) "true") (eq ( env "KIAM_INSTALLED" | default "true" ) "true" ) }}
   values:
   - serviceMonitors:
-      default:
+      server:
         labels:
           app: prometheus-operator-prometheus
         selector:
           matchLabels:
             app: kiam
             release: kiam
+            component: server
         namespaceSelector:
           matchNames:
             - kube-system
         endpoints:
           - port: "metrics"
             interavl: 15s
+      agent:
+        labels:
+          app: prometheus-operator-prometheus
+        selector:
+          matchLabels:
+            app: kiam
+            release: kiam
+            component: agent
+        namespaceSelector:
+          matchNames:
+            - kube-system
+        endpoints:
+          - port: "metrics"
+            interavl: 15s
+    prometheusRules:
+      default:
+        labels:
+          app: prometheus-operator-prometheus
+        groups:
+          - name: kiam.rules
+            rules:
+            - alert: kiam_sts_issuing_errors_total
+              annotations:
+                message: There are errors issuing credentials {{ $labels.namespace }}/{{ $labels.pod }}
+              expr: {{ env "KIAM_ALERT_STS_ISSUING_ERROR_TOTAL_WARNING_EXPR" | default "kiam_sts_issuing_errors_total >= 1" }}
+              labels:
+                severity: warning
+            - alert: kiam_sts_issuing_errors_total
+              annotations:
+                message: There are errors issuing credentials {{ $labels.namespace }}/{{ $labels.pod }}
+              expr: {{ env "KIAM_ALERT_STS_ISSUING_ERROR_TOTAL_CRITICAL_EXPR" | default "avg_over_time(kiam_sts_issuing_errors_total[1m]) >= 1" }}
+              labels:
+                severity: critical
+
+            - alert: kiam_metadata_find_role_errors_total
+              annotations:
+                message: There are errors issuing credentials {{ $labels.namespace }}/{{ $labels.pod }}
+              expr: {{ env "KIAM_ALERT_METADATA_FIND_ROLE_ERRORS_TOTAL_WARNING_EXPR" | default "kiam_metadata_find_role_errors_total >= 1" }}
+              labels:
+                severity: warning
+            - alert: kiam_metadata_find_role_errors_total
+              annotations:
+                message: There are errors issuing credentials {{ $labels.namespace }}/{{ $labels.pod }}
+              expr: {{ env "KIAM_ALERT_METADATA_FIND_ROLE_ERRORS_TOTAL_CRITICAL_EXPR" | default "avg_over_time(kiam_metadata_find_role_errors_total[1m]) >= 1" }}
+              labels:
+                severity: critical

--- a/releases/kiam.yaml
+++ b/releases/kiam.yaml
@@ -198,7 +198,7 @@ releases:
           caFileName:   ca.crt
         updateStrategy: RollingUpdate
 
-- name: 'kiam-promtheus'
+- name: 'kiam-prometheus'
   namespace: kube-system
   labels:
     component: "iam"

--- a/releases/kiam.yaml
+++ b/releases/kiam.yaml
@@ -174,7 +174,6 @@ releases:
           # pod's assigned IAM role and corresponding credentials. Here we return to essentially full
           # access to the metadata, while also doing a sanity check on the URL and giving you a template
           # in case you want to restrict access to one section of data.
-          # whitelist-route-regexp: '^/latest/(meta-data|user-data|dynamic)/'
           whitelist-route-regexp: '.*'
       server:
         gatewayTimeoutCreation: "5s"

--- a/releases/kiam.yaml
+++ b/releases/kiam.yaml
@@ -253,7 +253,7 @@ releases:
               annotations:
                 message: There are errors issuing credentials
                 description: Number of errors issuing credentials
-                logs: {{ env "KUBANA_EXTERNAL_URL" }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"error%20requesting%20credentials"'),sort:!('@timestamp',desc))
+                logs: {{ env "KIBANA_EXTERNAL_URL" }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"error%20requesting%20credentials"'),sort:!('@timestamp',desc))
               expr: {{ env "KIAM_ALERT_STS_ISSUING_ERROR_TOTAL_WARNING_EXPR" | default "increase(kiam_sts_issuing_errors_total[1m]) >= 1" }}
               labels:
                 severity: warning
@@ -261,7 +261,7 @@ releases:
               annotations:
                 message: There are errors issuing credentials
                 description: Number of errors issuing credentials
-                logs: {{ env "KUBANA_EXTERNAL_URL" }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"error%20requesting%20credentials"'),sort:!('@timestamp',desc))
+                logs: {{ env "KIBANA_EXTERNAL_URL" }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"error%20requesting%20credentials"'),sort:!('@timestamp',desc))
               expr: {{ env "KIAM_ALERT_STS_ISSUING_ERROR_TOTAL_CRITICAL_EXPR" | default "increase(kiam_sts_issuing_errors_total[5m]) >= 1" }}
               labels:
                 severity: critical
@@ -270,7 +270,7 @@ releases:
               annotations:
                 message: Pod try to use non-exiting role
                 description: Number of errors finding the role for a pod
-                logs: {{ env "KUBANA_EXTERNAL_URL" }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'%22error%20finding%20role%20for%20pod%22'),sort:!('@timestamp',desc))
+                logs: {{ env "KIBANA_EXTERNAL_URL" }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'%22error%20finding%20role%20for%20pod%22'),sort:!('@timestamp',desc))
               expr: {{ env "KIAM_ALERT_METADATA_FIND_ROLE_ERRORS_TOTAL_WARNING_EXPR" | default "increase(kiam_metadata_find_role_errors_total[1m]) >= 1" }}
               labels:
                 severity: warning
@@ -278,7 +278,7 @@ releases:
               annotations:
                 message: Pod try to use non-exiting role
                 description: Number of errors finding the role for a pod
-                logs: {{ env "KUBANA_EXTERNAL_URL" }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'%22error%20finding%20role%20for%20pod%22'),sort:!('@timestamp',desc))
+                logs: {{ env "KIBANA_EXTERNAL_URL" }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'%22error%20finding%20role%20for%20pod%22'),sort:!('@timestamp',desc))
               expr: {{ env "KIAM_ALERT_METADATA_FIND_ROLE_ERRORS_TOTAL_CRITICAL_EXPR" | default "increase(kiam_metadata_find_role_errors_total[5m]) >= 1" }}
               labels:
                 severity: critical
@@ -287,7 +287,7 @@ releases:
               annotations:
                 message: Pod try to use empty role
                 description: Number of empty roles returned
-                logs: {{ env "KUBANA_EXTERNAL_URL" }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"empty%20role"'),sort:!('@timestamp',desc))
+                logs: {{ env "KIBANA_EXTERNAL_URL" }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"empty%20role"'),sort:!('@timestamp',desc))
               expr: {{ env "KIAM_ALERT_METADATA_EMPTY_ROLE_TOTAL_WARNING_EXPR" | default "increase(kiam_metadata_empty_role_total[1m]) >= 1" }}
               labels:
                 severity: warning
@@ -295,7 +295,7 @@ releases:
               annotations:
                 message: Pod try to use empty role
                 description: Number of empty roles returned
-                logs: {{ env "KUBANA_EXTERNAL_URL" }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"empty%20role"'),sort:!('@timestamp',desc))
+                logs: {{ env "KIBANA_EXTERNAL_URL" }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"empty%20role"'),sort:!('@timestamp',desc))
               expr: {{ env "KIAM_ALERT_METADATA_EMPTY_ROLE_TOTAL_CRITICAL_EXPR" | default "increase(kiam_metadata_empty_role_total[5m]) >= 1" }}
               labels:
                 severity: critical
@@ -304,7 +304,7 @@ releases:
               annotations:
                 message: Error fetch aws credentials
                 description: Number of errors fetching the credentials for a pod
-                logs: {{ env "KUBANA_EXTERNAL_URL" }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"error%20fetching%20credentials"'),sort:!('@timestamp',desc))
+                logs: {{ env "KIBANA_EXTERNAL_URL" }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"error%20fetching%20credentials"'),sort:!('@timestamp',desc))
               expr: {{ env "KIAM_ALERT_METADATA_CREDENTIAL_FETCH_ERRORS_TOTAL_WARNING_EXPR" | default "increase(kiam_metadata_credential_fetch_errors_total[1m]) >= 1" }}
               labels:
                 severity: warning
@@ -312,7 +312,7 @@ releases:
               annotations:
                 message: Error fetch aws credentials
                 description: Number of errors fetching the credentials for a pod
-                logs: {{ env "KUBANA_EXTERNAL_URL" }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"error%20fetching%20credentials"'),sort:!('@timestamp',desc))
+                logs: {{ env "KIBANA_EXTERNAL_URL" }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"error%20fetching%20credentials"'),sort:!('@timestamp',desc))
               expr: {{ env "KIAM_ALERT_METADATA_CREDENTIAL_FETCH_ERRORS_TOTAL_CRITICAL_EXPR" | default "increase(kiam_metadata_credential_fetch_errors_total[5m]) >= 1" }}
               labels:
                 severity: critical
@@ -321,7 +321,7 @@ releases:
               annotations:
                 message: Assuming role blocked because of namespace annotations `iam.amazonaws.com/permitted`
                 description: Number of access requests to the proxy handler that were blocked by the regexp
-                logs: {{ env "KUBANA_EXTERNAL_URL" }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"request%20blocked%20by%20whitelist-route-regexp"'),sort:!('@timestamp',desc))
+                logs: {{ env "KIBANA_EXTERNAL_URL" }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"request%20blocked%20by%20whitelist-route-regexp"'),sort:!('@timestamp',desc))
               expr: {{ env "KIAM_ALERT_METADATA_PROXY_REQUESTS_BLOCKED_TOTAL_WARNING_EXPR" | default "increase(kiam_metadata_proxy_requests_blocked_total[1m]) >= 1" }}
               labels:
                 severity: warning
@@ -329,7 +329,7 @@ releases:
               annotations:
                 message: Assuming role blocked because of namespace annotations `iam.amazonaws.com/permitted`
                 description: Number of access requests to the proxy handler that were blocked by the regexp
-                logs: {{ env "KUBANA_EXTERNAL_URL" }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"request%20blocked%20by%20whitelist-route-regexp"'),sort:!('@timestamp',desc))
+                logs: {{ env "KIBANA_EXTERNAL_URL" }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"request%20blocked%20by%20whitelist-route-regexp"'),sort:!('@timestamp',desc))
               expr: {{ env "KIAM_ALERT_METADATA_PROXY_REQUESTS_BLOCKED_TOTAL_CRITICAL_EXPR" | default "increase(kiam_metadata_proxy_requests_blocked_total[5m]) >= 1" }}
               labels:
                 severity: critical

--- a/releases/kiam.yaml
+++ b/releases/kiam.yaml
@@ -174,7 +174,8 @@ releases:
           # pod's assigned IAM role and corresponding credentials. Here we return to essentially full
           # access to the metadata, while also doing a sanity check on the URL and giving you a template
           # in case you want to restrict access to one section of data.
-          whitelist-route-regexp: '^/latest/(meta-data|user-data|dynamic)/'
+          # whitelist-route-regexp: '^/latest/(meta-data|user-data|dynamic)/'
+          whitelist-route-regexp: '.*'
       server:
         gatewayTimeoutCreation: "5s"
         nodeSelector:

--- a/releases/kiam.yaml
+++ b/releases/kiam.yaml
@@ -251,7 +251,7 @@ releases:
             - alert: kiam_sts_issuing_errors_total
               annotations:
                 message: There are errors issuing credentials
-              expr: {{ env "KIAM_ALERT_STS_ISSUING_ERROR_TOTAL_WARNING_EXPR" | default "increase(kiam_sts_issuing_errors_total[1m])(kiam_sts_issuing_errors_total[1m]) >= 1" }}
+              expr: {{ env "KIAM_ALERT_STS_ISSUING_ERROR_TOTAL_WARNING_EXPR" | default "increase(kiam_sts_issuing_errors_total[1m]) >= 1" }}
               labels:
                 severity: warning
             - alert: kiam_sts_issuing_errors_total
@@ -264,7 +264,7 @@ releases:
             - alert: kiam_metadata_find_role_errors_total
               annotations:
                 message: Pod try to use non-exiting role
-              expr: {{ env "KIAM_ALERT_METADATA_FIND_ROLE_ERRORS_TOTAL_WARNING_EXPR" | default "increase(kiam_metadata_find_role_errors_total) >= 1" }}
+              expr: {{ env "KIAM_ALERT_METADATA_FIND_ROLE_ERRORS_TOTAL_WARNING_EXPR" | default "increase(kiam_metadata_find_role_errors_total[1m]) >= 1" }}
               labels:
                 severity: warning
             - alert: kiam_metadata_find_role_errors_total

--- a/releases/kiam.yaml
+++ b/releases/kiam.yaml
@@ -251,25 +251,25 @@ releases:
             - alert: kiam_sts_issuing_errors_total
               annotations:
                 message: There are errors issuing credentials
-              expr: {{ env "KIAM_ALERT_STS_ISSUING_ERROR_TOTAL_WARNING_EXPR" | default "kiam_sts_issuing_errors_total >= 1" }}
+              expr: {{ env "KIAM_ALERT_STS_ISSUING_ERROR_TOTAL_WARNING_EXPR" | default "increase(kiam_sts_issuing_errors_total[1m])(kiam_sts_issuing_errors_total[1m]) >= 1" }}
               labels:
                 severity: warning
             - alert: kiam_sts_issuing_errors_total
               annotations:
                 message: There are errors issuing credentials
-              expr: {{ env "KIAM_ALERT_STS_ISSUING_ERROR_TOTAL_CRITICAL_EXPR" | default "avg_over_time(kiam_sts_issuing_errors_total[1m]) >= 1" }}
+              expr: {{ env "KIAM_ALERT_STS_ISSUING_ERROR_TOTAL_CRITICAL_EXPR" | default "increase(kiam_sts_issuing_errors_total[5m]) >= 1" }}
               labels:
                 severity: critical
 
             - alert: kiam_metadata_find_role_errors_total
               annotations:
                 message: Pod try to use non-exiting role
-              expr: {{ env "KIAM_ALERT_METADATA_FIND_ROLE_ERRORS_TOTAL_WARNING_EXPR" | default "kiam_metadata_find_role_errors_total >= 1" }}
+              expr: {{ env "KIAM_ALERT_METADATA_FIND_ROLE_ERRORS_TOTAL_WARNING_EXPR" | default "increase(kiam_metadata_find_role_errors_total) >= 1" }}
               labels:
                 severity: warning
             - alert: kiam_metadata_find_role_errors_total
               annotations:
                 message: Pod try to use non-exiting role
-              expr: {{ env "KIAM_ALERT_METADATA_FIND_ROLE_ERRORS_TOTAL_CRITICAL_EXPR" | default "avg_over_time(kiam_metadata_find_role_errors_total[1m]) >= 1" }}
+              expr: {{ env "KIAM_ALERT_METADATA_FIND_ROLE_ERRORS_TOTAL_CRITICAL_EXPR" | default "increase(kiam_metadata_find_role_errors_total[5m]) >= 1" }}
               labels:
                 severity: critical

--- a/releases/kiam.yaml
+++ b/releases/kiam.yaml
@@ -252,7 +252,7 @@ releases:
               annotations:
                 message: There are errors issuing credentials
                 description: Number of errors issuing credentials
-                logs: <a href="{{ $prometheusBaseUrl }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"error%20requesting%20credentials"'),sort:!('@timestamp',desc))">Check logs</a>
+                logs: {{ $prometheusBaseUrl }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"error%20requesting%20credentials"'),sort:!('@timestamp',desc))
               expr: {{ env "KIAM_ALERT_STS_ISSUING_ERROR_TOTAL_WARNING_EXPR" | default "increase(kiam_sts_issuing_errors_total[1m]) >= 1" }}
               labels:
                 severity: warning
@@ -260,7 +260,7 @@ releases:
               annotations:
                 message: There are errors issuing credentials
                 description: Number of errors issuing credentials
-                logs: <a href="{{ $prometheusBaseUrl }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"error%20requesting%20credentials"'),sort:!('@timestamp',desc))">Check logs</a>
+                logs: {{ $prometheusBaseUrl }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"error%20requesting%20credentials"'),sort:!('@timestamp',desc))
               expr: {{ env "KIAM_ALERT_STS_ISSUING_ERROR_TOTAL_CRITICAL_EXPR" | default "increase(kiam_sts_issuing_errors_total[5m]) >= 1" }}
               labels:
                 severity: critical
@@ -269,7 +269,7 @@ releases:
               annotations:
                 message: Pod try to use non-exiting role
                 description: Number of errors finding the role for a pod
-                logs: <a href="{{ $prometheusBaseUrl }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'%22error%20finding%20role%20for%20pod%22'),sort:!('@timestamp',desc))">Check logs</a>
+                logs: {{ $prometheusBaseUrl }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'%22error%20finding%20role%20for%20pod%22'),sort:!('@timestamp',desc))
               expr: {{ env "KIAM_ALERT_METADATA_FIND_ROLE_ERRORS_TOTAL_WARNING_EXPR" | default "increase(kiam_metadata_find_role_errors_total[1m]) >= 1" }}
               labels:
                 severity: warning
@@ -277,7 +277,7 @@ releases:
               annotations:
                 message: Pod try to use non-exiting role
                 description: Number of errors finding the role for a pod
-                logs: <a href="{{ $prometheusBaseUrl }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'%22error%20finding%20role%20for%20pod%22'),sort:!('@timestamp',desc))">Check logs</a>
+                logs: {{ $prometheusBaseUrl }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'%22error%20finding%20role%20for%20pod%22'),sort:!('@timestamp',desc))
               expr: {{ env "KIAM_ALERT_METADATA_FIND_ROLE_ERRORS_TOTAL_CRITICAL_EXPR" | default "increase(kiam_metadata_find_role_errors_total[5m]) >= 1" }}
               labels:
                 severity: critical
@@ -286,7 +286,7 @@ releases:
               annotations:
                 message: Pod try to use empty role
                 description: Number of empty roles returned
-                logs: <a href="{{ $prometheusBaseUrl }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"empty%20role"'),sort:!('@timestamp',desc))">Check logs</a>
+                logs: {{ $prometheusBaseUrl }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"empty%20role"'),sort:!('@timestamp',desc))
               expr: {{ env "KIAM_ALERT_METADATA_EMPTY_ROLE_TOTAL_WARNING_EXPR" | default "increase(kiam_metadata_empty_role_total[1m]) >= 1" }}
               labels:
                 severity: warning
@@ -294,7 +294,7 @@ releases:
               annotations:
                 message: Pod try to use empty role
                 description: Number of empty roles returned
-                logs: <a href="{{ $prometheusBaseUrl }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"empty%20role"'),sort:!('@timestamp',desc))">Check logs</a>
+                logs: {{ $prometheusBaseUrl }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"empty%20role"'),sort:!('@timestamp',desc))
               expr: {{ env "KIAM_ALERT_METADATA_EMPTY_ROLE_TOTAL_CRITICAL_EXPR" | default "increase(kiam_metadata_empty_role_total[5m]) >= 1" }}
               labels:
                 severity: critical
@@ -303,7 +303,7 @@ releases:
               annotations:
                 message: Error fetch aws credentials
                 description: Number of errors fetching the credentials for a pod
-                runbook_url: <a href="{{ $prometheusBaseUrl }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"error%20fetching%20credentials"'),sort:!('@timestamp',desc))">Check logs</a>
+                logs: {{ $prometheusBaseUrl }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"error%20fetching%20credentials"'),sort:!('@timestamp',desc))
               expr: {{ env "KIAM_ALERT_METADATA_CREDENTIAL_FETCH_ERRORS_TOTAL_WARNING_EXPR" | default "increase(kiam_metadata_credential_fetch_errors_total[1m]) >= 1" }}
               labels:
                 severity: warning
@@ -311,7 +311,7 @@ releases:
               annotations:
                 message: Error fetch aws credentials
                 description: Number of errors fetching the credentials for a pod
-                runbook_url: <a href="{{ $prometheusBaseUrl }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"error%20fetching%20credentials"'),sort:!('@timestamp',desc))">Check logs</a>
+                logs: {{ $prometheusBaseUrl }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"error%20fetching%20credentials"'),sort:!('@timestamp',desc))
               expr: {{ env "KIAM_ALERT_METADATA_CREDENTIAL_FETCH_ERRORS_TOTAL_CRITICAL_EXPR" | default "increase(kiam_metadata_credential_fetch_errors_total[5m]) >= 1" }}
               labels:
                 severity: critical
@@ -320,7 +320,7 @@ releases:
               annotations:
                 message: Assuming role blocked because of namespace annotations `iam.amazonaws.com/permitted`
                 description: Number of access requests to the proxy handler that were blocked by the regexp
-                runbook_url: <a href="{{ $prometheusBaseUrl }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"request%20blocked%20by%20whitelist-route-regexp"'),sort:!('@timestamp',desc))">Check logs</a>
+                logs: {{ $prometheusBaseUrl }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"request%20blocked%20by%20whitelist-route-regexp"'),sort:!('@timestamp',desc))
               expr: {{ env "KIAM_ALERT_METADATA_PROXY_REQUESTS_BLOCKED_TOTAL_WARNING_EXPR" | default "increase(kiam_metadata_proxy_requests_blocked_total[1m]) >= 1" }}
               labels:
                 severity: warning
@@ -328,7 +328,7 @@ releases:
               annotations:
                 message: Assuming role blocked because of namespace annotations `iam.amazonaws.com/permitted`
                 description: Number of access requests to the proxy handler that were blocked by the regexp
-                runbook_url: <a href="{{ $prometheusBaseUrl }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"request%20blocked%20by%20whitelist-route-regexp"'),sort:!('@timestamp',desc))">Check logs</a>
+                logs: {{ $prometheusBaseUrl }}/_plugin/kibana/app/kibana#/discover?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-15m,mode:quick,to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'logstash-*',key:kubernetes.labels.release,negate:!f,params:(query:kiam,type:phrase),type:phrase,value:kiam),query:(match:(kubernetes.labels.release:(query:kiam,type:phrase))))),index:'logstash-*',interval:auto,query:(language:lucene,query:'"request%20blocked%20by%20whitelist-route-regexp"'),sort:!('@timestamp',desc))
               expr: {{ env "KIAM_ALERT_METADATA_PROXY_REQUESTS_BLOCKED_TOTAL_CRITICAL_EXPR" | default "increase(kiam_metadata_proxy_requests_blocked_total[5m]) >= 1" }}
               labels:
                 severity: critical

--- a/releases/kiam.yaml
+++ b/releases/kiam.yaml
@@ -250,26 +250,26 @@ releases:
             rules:
             - alert: kiam_sts_issuing_errors_total
               annotations:
-                message: There are errors issuing credentials {{ $labels.namespace }}/{{ $labels.pod }}
+                message: There are errors issuing credentials
               expr: {{ env "KIAM_ALERT_STS_ISSUING_ERROR_TOTAL_WARNING_EXPR" | default "kiam_sts_issuing_errors_total >= 1" }}
               labels:
                 severity: warning
             - alert: kiam_sts_issuing_errors_total
               annotations:
-                message: There are errors issuing credentials {{ $labels.namespace }}/{{ $labels.pod }}
+                message: There are errors issuing credentials
               expr: {{ env "KIAM_ALERT_STS_ISSUING_ERROR_TOTAL_CRITICAL_EXPR" | default "avg_over_time(kiam_sts_issuing_errors_total[1m]) >= 1" }}
               labels:
                 severity: critical
 
             - alert: kiam_metadata_find_role_errors_total
               annotations:
-                message: There are errors issuing credentials {{ $labels.namespace }}/{{ $labels.pod }}
+                message: Pod try to use non-exiting role
               expr: {{ env "KIAM_ALERT_METADATA_FIND_ROLE_ERRORS_TOTAL_WARNING_EXPR" | default "kiam_metadata_find_role_errors_total >= 1" }}
               labels:
                 severity: warning
             - alert: kiam_metadata_find_role_errors_total
               annotations:
-                message: There are errors issuing credentials {{ $labels.namespace }}/{{ $labels.pod }}
+                message: Pod try to use non-exiting role
               expr: {{ env "KIAM_ALERT_METADATA_FIND_ROLE_ERRORS_TOTAL_CRITICAL_EXPR" | default "avg_over_time(kiam_metadata_find_role_errors_total[1m]) >= 1" }}
               labels:
                 severity: critical

--- a/releases/kiam.yaml
+++ b/releases/kiam.yaml
@@ -225,6 +225,7 @@ releases:
         endpoints:
           - port: "metrics"
             interavl: 15s
+
       agent:
         labels:
           app: prometheus-operator-prometheus
@@ -239,6 +240,7 @@ releases:
         endpoints:
           - port: "metrics"
             interavl: 15s
+
     prometheusRules:
       default:
         labels:


### PR DESCRIPTION
## what
1. [kiam] Added Prometheus alerts
2. [elasticsearch-exporter] disabled resources limits

## why
1. To be informed about problems with KIAM
2. To solve CPU throttling problem https://github.com/kubernetes/kubernetes/issues/67577

```
Elasticsearch Exporter gets unfairly throttled even if
the limit is 10 times the actual usage. With a request of 5m and usage of 3m,
setting the limit to 100m still results in throttling about 30% of the time
```
