### PR TITLE
support ForecastleApp CRDs

### DIFF
--- a/releases/forecastle.yaml
+++ b/releases/forecastle.yaml
@@ -40,7 +40,7 @@ releases:
       - {{ env "FORECASTLE_CUSTOM_APPS_YAML" }}
       {{- end }}
       - forecastle:
-          createCustomResource: false
+          createCustomResource: {{ env "FORECASTLE_CREATE_CRD" | default "true" }}
           image:
             pullPolicy: "IfNotPresent"
           namespace: '{{ env "FORECASTLE_NAMESPACE" | default "kube-system" }}'

--- a/releases/forecastle.yaml
+++ b/releases/forecastle.yaml
@@ -5,7 +5,8 @@ repositories:
     # url: "git+https://github.com/stakater/Forecastle@deployments/kubernetes/chart?ref=v1.0.22"
     # v1.0.22: url: "git+https://github.com/stakater/Forecastle@deployments/kubernetes/chart?ref=8d6e5cd2dba3ad6c265ae94138c40276425b7634"
     # v1.0.25 url: "git+https://github.com/stakater/Forecastle@deployments/kubernetes/chart?ref=8f36b82beaf2a1a42b364a3857bc83638c51e30b"
-    url: "git+https://github.com/stakater/Forecastle@deployments/kubernetes/chart?ref=ffb5179aa659e0e3cf0ca20e1c8bd94c5fd66a2e"
+    # v1.0.34 url: "git+https://github.com/stakater/Forecastle@deployments/kubernetes/chart?ref=19b369aa684152ad52c33d1935a74b0f425db2cb"
+    url: "git+https://github.com/stakater/Forecastle@deployments/kubernetes/chart?ref=19b369aa684152ad52c33d1935a74b0f425db2cb"
 
 releases:
 
@@ -29,7 +30,7 @@ releases:
       vendor: "stakater"
       default: "false"
     chart: "forecastle/forecastle"
-    version: "v1.0.27"
+    version: "v1.0.34"
     wait: false
     installed: {{ env "FORECASTLE_INSTALLED" | default "true" }}
     force: true
@@ -39,6 +40,7 @@ releases:
       - {{ env "FORECASTLE_CUSTOM_APPS_YAML" }}
       {{- end }}
       - forecastle:
+          createCustomResource: false
           image:
             pullPolicy: "IfNotPresent"
           namespace: '{{ env "FORECASTLE_NAMESPACE" | default "kube-system" }}'

--- a/releases/istio-gatekeeper.yaml
+++ b/releases/istio-gatekeeper.yaml
@@ -15,7 +15,8 @@ repositories:
   # url: "git+https://github.com/stakater/Forecastle@deployments/kubernetes/chart?ref=v1.0.22"
   # v1.0.22: url: "git+https://github.com/stakater/Forecastle@deployments/kubernetes/chart?ref=8d6e5cd2dba3ad6c265ae94138c40276425b7634"
   # v1.0.25 url: "git+https://github.com/stakater/Forecastle@deployments/kubernetes/chart?ref=8f36b82beaf2a1a42b364a3857bc83638c51e30b"
-  url: "git+https://github.com/stakater/Forecastle@deployments/kubernetes/chart?ref=ffb5179aa659e0e3cf0ca20e1c8bd94c5fd66a2e"
+  # v1.0.34 url: "git+https://github.com/stakater/Forecastle@deployments/kubernetes/chart?ref=19b369aa684152ad52c33d1935a74b0f425db2cb"
+  url: "git+https://github.com/stakater/Forecastle@deployments/kubernetes/chart?ref=19b369aa684152ad52c33d1935a74b0f425db2cb"
 
 releases:
 
@@ -207,7 +208,7 @@ releases:
     vendor: "stakater"
     default: "false"
   chart: "forecastle/forecastle"
-  version: "v1.0.27"
+  version: "v1.0.34"
   wait: false
   installed: {{ env "ISTIO_GATEKEEPER_FORECASTLE_INSTALLED" | default "true" }}
   force: true
@@ -216,6 +217,7 @@ releases:
     - nameOverride: istio-gatekeeper-forecastle
       fullNameOverride: istio-gatekeeper-forecastle
       forecastle:
+        createCustomResource: true
         image:
           pullPolicy: "IfNotPresent"
         namespace: "istio-system"


### PR DESCRIPTION
## what
1. [forecastle] (upgrade to v1.0.34)
2. [istio-gatekeeper] (upgrade istio-gatekeeper-forecastle to v1.0.34 to use CRDs support)

## why
1. to be consistent with istio-gatekeeper-forecastle
2. to be able to use ForecastleApp CRDs and avoid using `fake` ingresses to register the application in forecastle.
