### PR TITLE
[nginx-ingress] Add support for PROXY protocol

### DIFF
--- a/releases/nginx-ingress.yaml
+++ b/releases/nginx-ingress.yaml
@@ -67,6 +67,9 @@ releases:
             {{- if eq ( env "NGINX_INGRESS_NLB_ENABLED" | default "false" ) "true" }}
             service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
             {{- end }}
+            {{- if eq ( env "NGINX_INGRESS_USE_PROXY_PROTOCOL" | default "false" ) "true" }}
+            service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
+            {{- end }}
         updateStrategy:
           rollingUpdate:
             maxUnavailable: 1

--- a/releases/nginx-ingress.yaml
+++ b/releases/nginx-ingress.yaml
@@ -55,6 +55,7 @@ releases:
         ingressClass: '{{ env "NGINX_INGRESS_CLASS" | default "nginx" }}'
         config:
           custom-http-errors: '{{ join "," $client_errors }},{{ join "," $server_errors }}'
+          use-proxy-protocol: '{{ env "NGINX_INGRESS_USE_PROXY_PROTOCOL" | default "false" }}'
         service:
           externalTrafficPolicy: '{{ env "NGINX_INGRESS_EXTERNAL_TRAFFIC_POLICY" | default "Cluster" }}'
           annotations:


### PR DESCRIPTION
## what
1. [nginx-ingress] This adds configurability (via env `NGINX_INGRESS_USE_PROXY_PROTOCOL`) to use the PROXY protocol headers to requests

## why
1. Allow better communication of things like the actual client IP for the request, which was my use case.

## references
1. ELB Prereqs: https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-proxy-protocol.html#proxy-protocol-prerequisites (of note, we only have tcp:tcp connections, so this works great)
2. Annotation: https://github.com/kubernetes/kubernetes/pull/24569
3. ConfigMap settings in the helm chart: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/configmap.md#use-proxy-protocol