### PR TITLE
Add helmfile for EKS `external-dns`

### DIFF
--- a/releases/eks/external-dns.yaml
+++ b/releases/eks/external-dns.yaml
@@ -59,11 +59,10 @@ releases:
         ## If true, create & use RBAC resources
         ##
         ### Optional: RBAC_ENABLED;
-        create: {{ env "EXTERNAL_DNS_RBAC_ENABLED" | default "true" }}
+        create: {{ env "RBAC_ENABLED" | default "false" }}
         ## Service Account for pods
         ### Optional: EXTERNAL_DNS_RBAC_SERVICE_ACCOUNT_NAME;
         ## https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
-        ##
         serviceAccountName: '{{ env "EXTERNAL_DNS_RBAC_SERVICE_ACCOUNT_NAME" | default "external-dns" }}'
         ## Annotations for the Service Account
         ##

--- a/releases/eks/external-dns.yaml
+++ b/releases/eks/external-dns.yaml
@@ -59,8 +59,8 @@ releases:
         serviceAccountName: '{{ env "EXTERNAL_DNS_RBAC_SERVICE_ACCOUNT_NAME" | default "external-dns" }}'
         ## Annotations for the Service Account
 {{- if env "EXTERNAL_DNS_PROVIDER" | default "aws" | eq "aws" }}
-        serviceAccountAnnotations:
-          eks.amazonaws.com/role-arn: '{{ env "EXTERNAL_DNS_IAM_ROLE" }}'
+        #serviceAccountAnnotations:
+        #  eks.amazonaws.com/role-arn: '{{ env "EXTERNAL_DNS_IAM_ROLE" }}'
 {{- end }}
         ## RBAC API version
         apiVersion: v1

--- a/releases/eks/external-dns.yaml
+++ b/releases/eks/external-dns.yaml
@@ -29,12 +29,9 @@ releases:
 {{- if env "EXTERNAL_DNS_CRD_ENABLED" | default "false" | eq "true" }}
       - crd
 {{- end }}
-      ### Required: EXTERNAL_DNS_TXT_OWNER_ID; e.g. us-west-2.staging.cloudposse.org
       txtOwnerId: '{{ env "EXTERNAL_DNS_TXT_OWNER_ID" }}'
-      ### Required: EXTERNAL_DNS_TXT_PREFIX; e.g. 11591833-F9CE-407C-8519-35A947DB1D87-
       txtPrefix: '{{ env "EXTERNAL_DNS_TXT_PREFIX" }}'
       publishInternalServices: true
-      ### Optional: EXTERNAL_DNS_POLICY Modify (options: sync, upsert-only )
       policy:  '{{ env "EXTERNAL_DNS_POLICY" | default "sync" }}'
       provider: '{{ env "EXTERNAL_DNS_PROVIDER" | default "aws" }}'
 {{ if env "EXTERNAL_DNS_PROVIDER" | default "aws" | eq "cloudflare" }}
@@ -56,23 +53,16 @@ releases:
           cpu: '{{ env "EXTERNAL_DNS_REQUEST_CPU" | default "100m" }}'
           memory: '{{ env "EXTERNAL_DNS_REQUEST_MEMORY" | default "128Mi" }}'
       rbac:
-        ## If true, create & use RBAC resources
-        ##
-        ### Optional: RBAC_ENABLED;
-        create: {{ env "RBAC_ENABLED" | default "false" }}
+        create: {{ env "RBAC_ENABLED" | default "true" }}
         ## Service Account for pods
-        ### Optional: EXTERNAL_DNS_RBAC_SERVICE_ACCOUNT_NAME;
         ## https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
         serviceAccountName: '{{ env "EXTERNAL_DNS_RBAC_SERVICE_ACCOUNT_NAME" | default "external-dns" }}'
         ## Annotations for the Service Account
-        ##
 {{- if env "EXTERNAL_DNS_PROVIDER" | default "aws" | eq "aws" }}
         serviceAccountAnnotations:
           eks.amazonaws.com/role-arn: '{{ env "EXTERNAL_DNS_IAM_ROLE" }}'
 {{- end }}
         ## RBAC API version
-        ##
         apiVersion: v1
         ## Podsecuritypolicy
-        ##
         pspEnabled: false

--- a/releases/eks/external-dns.yaml
+++ b/releases/eks/external-dns.yaml
@@ -59,8 +59,8 @@ releases:
         serviceAccountName: '{{ env "EXTERNAL_DNS_RBAC_SERVICE_ACCOUNT_NAME" | default "external-dns" }}'
         ## Annotations for the Service Account
 {{- if env "EXTERNAL_DNS_PROVIDER" | default "aws" | eq "aws" }}
-        #serviceAccountAnnotations:
-        #  eks.amazonaws.com/role-arn: '{{ env "EXTERNAL_DNS_IAM_ROLE" }}'
+        serviceAccountAnnotations:
+          eks.amazonaws.com/role-arn: '{{ env "EXTERNAL_DNS_IAM_ROLE" }}'
 {{- end }}
         ## RBAC API version
         apiVersion: v1

--- a/releases/eks/external-dns.yaml
+++ b/releases/eks/external-dns.yaml
@@ -1,0 +1,79 @@
+repositories:
+# Stable repo of official helm charts
+- name: "stable"
+  url: "https://kubernetes-charts.storage.googleapis.com"
+
+releases:
+
+#
+# References:
+#   - https://github.com/kubernetes/charts/blob/master/stable/external-dns/values.yaml
+#
+- name: "external-dns"
+  namespace: "kube-system"
+  labels:
+    chart: "external-dns"
+    repo: "stable"
+    component: "dns"
+    namespace: "kube-system"
+    vendor: "kubernetes"
+    default: "true"
+  chart: "stable/external-dns"
+  version: "2.13.0"
+  wait: true
+  installed: {{ env "EXTERNAL_DNS_INSTALLED" | default "true" }}
+  values:
+    - sources:
+      - service
+      - ingress
+{{- if env "EXTERNAL_DNS_CRD_ENABLED" | default "false" | eq "true" }}
+      - crd
+{{- end }}
+      ### Required: EXTERNAL_DNS_TXT_OWNER_ID; e.g. us-west-2.staging.cloudposse.org
+      txtOwnerId: '{{ env "EXTERNAL_DNS_TXT_OWNER_ID" }}'
+      ### Required: EXTERNAL_DNS_TXT_PREFIX; e.g. 11591833-F9CE-407C-8519-35A947DB1D87-
+      txtPrefix: '{{ env "EXTERNAL_DNS_TXT_PREFIX" }}'
+      publishInternalServices: true
+      ### Optional: EXTERNAL_DNS_POLICY Modify (options: sync, upsert-only )
+      policy:  '{{ env "EXTERNAL_DNS_POLICY" | default "sync" }}'
+      provider: '{{ env "EXTERNAL_DNS_PROVIDER" | default "aws" }}'
+{{ if env "EXTERNAL_DNS_PROVIDER" | default "aws" | eq "cloudflare" }}
+      cloudflare:
+        apiKey: '{{ env "EXTERNAL_DNS_CLOUDFLARE_API_KEY" }}'
+        email: '{{ env "EXTERNAL_DNS_CLOUDFLARE_EMAIL" }}'
+{{ end }}
+
+      podAnnotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+      crd:
+        ## Install and use the integrated DNSEndpoint CRD
+        create: {{ env "EXTERNAL_DNS_CRD_ENABLED" | default "false" | quote }}
+      resources:
+        limits:
+          cpu: '{{ env "EXTERNAL_DNS_LIMIT_CPU" | default "200m" }}'
+          memory: '{{ env "EXTERNAL_DNS_LIMIT_MEMORY" | default "256Mi" }}'
+        requests:
+          cpu: '{{ env "EXTERNAL_DNS_REQUEST_CPU" | default "100m" }}'
+          memory: '{{ env "EXTERNAL_DNS_REQUEST_MEMORY" | default "128Mi" }}'
+      rbac:
+        ## If true, create & use RBAC resources
+        ##
+        ### Optional: RBAC_ENABLED;
+        create: {{ env "EXTERNAL_DNS_RBAC_ENABLED" | default "true" }}
+        ## Service Account for pods
+        ### Optional: EXTERNAL_DNS_RBAC_SERVICE_ACCOUNT_NAME;
+        ## https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+        ##
+        serviceAccountName: '{{ env "EXTERNAL_DNS_RBAC_SERVICE_ACCOUNT_NAME" | default "external-dns" }}'
+        ## Annotations for the Service Account
+        ##
+{{- if env "EXTERNAL_DNS_PROVIDER" | default "aws" | eq "aws" }}
+        serviceAccountAnnotations:
+          eks.amazonaws.com/role-arn: '{{ env "EXTERNAL_DNS_IAM_ROLE" }}'
+{{- end }}
+        ## RBAC API version
+        ##
+        apiVersion: v1
+        ## Podsecuritypolicy
+        ##
+        pspEnabled: false


### PR DESCRIPTION
## what
1. Add helmfile for EKS `external-dns`
2. Activate RBAC
3. Use Service Account for `external-dns`

## why
1. Provision `external-dns` for EKS cluster (which is different from `external-dns` for `kops`)
2. Use IAM Role for Service Accounts to associate an IAM role with a Kubernetes service account. This service account can then provide AWS permissions to the containers in any pod that uses that service account

## references
* https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html

