### PR TITLE
[nginx-ingress] alert fix

### DIFF
--- a/releases/nginx-ingress.yaml
+++ b/releases/nginx-ingress.yaml
@@ -87,7 +87,7 @@ releases:
                 annotations:
                   description: Nginx ingress controller error
                   summary: NginxIngressControllerError
-                expr: nginx_ingress_controller_requests > {{ env "NGINX_INGRESS_METRICS_CONTROLLER_ERROR_ALERT" | default "100000" }}
+                expr: rate(nginx_ingress_controller_requests[5m]) > {{ env "NGINX_INGRESS_METRICS_CONTROLLER_ERROR_ALERT" | default "10" }}
                 labels:
                   severity: warning
           {{- end }}


### PR DESCRIPTION
## what
1. [nginx-ingress] alert rule fixed to use rate

## why
1. current alert expression used as is, but `nginx_ingress_controller_requests` metric is `counter` type. We need to use `rate/irate` functions to avoid `guaranteed` alert triggering.
