### PR TITLE
[kiam] Fix service account key name (#209)

### DIFF
--- a/releases/kiam.yaml
+++ b/releases/kiam.yaml
@@ -142,7 +142,7 @@ releases:
     - rbac:
         ### Optional: RBAC_ENABLED;
         create: {{ env "RBAC_ENABLED" | default "false" }}
-      serviceAccount:
+      serviceAccounts:
         agent:
           ### Optional: RBAC_ENABLED;
           create: {{ env "RBAC_ENABLED" | default "false" }}


### PR DESCRIPTION
## what
1. [kiam] Changed the service account key name to match `values.yaml` in the chart

## why
1. Allow the chart to work with RBAC and a custom service account name