### PR TITLE
[sentry] slack integration fix

### DIFF
--- a/releases/sentry.yaml
+++ b/releases/sentry.yaml
@@ -259,7 +259,7 @@ releases:
 {{ env "SENTRY_GITHUB_APP_PRIVATE_KEY" | default "" | indent 14 }}
 
           sentryConfPy: |
-            SLACK_INTEGRATION_USE_WST = True
+            SLACK_INTEGRATION_USE_WST = False
 
         ## Prometheus Exporter / Metrics
         ##


### PR DESCRIPTION
## what
1. [sentry] set SLACK_INTEGRATION_USE_WST to false

## why
1. This flag should be set to False to be able to integrate sentry with Slack
