### PR TITLE
[sentry] Update TTLs for initial delay 

### DIFF
--- a/releases/sentry.yaml
+++ b/releases/sentry.yaml
@@ -2,9 +2,6 @@ repositories:
   # Stable repo of official helm charts
   - name: "stable"
     url: "https://kubernetes-charts.storage.googleapis.com"
-  # Repo of new Kubernetes charts in development
-  - name: "kubernetes-incubator"
-    url: "https://kubernetes-charts-incubator.storage.googleapis.com"
 
 releases:
 
@@ -21,7 +18,7 @@ releases:
       repo: "stable"
       component: "monitoring"
       namespace: "sentry"
-      vendor: "kubernetes-helm"
+      vendor: "sentry"
     chart: "stable/sentry"
     version: '{{ env "SENTRY_CHART_VERSION" | default "3.1.0" }}'
     force: true
@@ -49,6 +46,18 @@ releases:
           nodeSelector: {}
           tolerations: []
           affinity: {}
+          livenessProbe:
+            failureThreshold: 5
+            initialDelaySeconds: 90
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 2
+          readinessProbe:
+            failureThreshold: 10
+            initialDelaySeconds: 90
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 2
           env:
             - name: SENTRY_SLACK_CLIENT_ID
               value: '{{ env "SENTRY_SLACK_CLIENT_ID" | default "" }}'

--- a/releases/sentry.yaml
+++ b/releases/sentry.yaml
@@ -20,7 +20,7 @@ releases:
       namespace: "sentry"
       vendor: "sentry"
     chart: "stable/sentry"
-    version: '{{ env "SENTRY_CHART_VERSION" | default "3.1.0" }}'
+    version: '{{ env "SENTRY_CHART_VERSION" | default "4.0.0" }}'
     force: true
     wait: true
     timeout: 600


### PR DESCRIPTION
Signed-off-by: Erik Osterman <erik@cloudposse.com>

## what
* Increase initial delay for healthchecks from 50 seconds to 90 seconds
* Increase chart version to [`4.0.0` which is required for these settings to take effect](https://github.com/helm/charts/pull/20295)

## why
* When sentry has a lot of data, or depending on the cluster load time, we've observed that a startup delay of 50 seconds (default) is not enough
* If it's not set high enough, `sentry` will be in a crashloop because health checks fail.

## references
* https://github.com/helm/charts/pull/20295