### PR TITLE
[istio] Add missing chart repo

### DIFF
--- a/releases/istio.yaml
+++ b/releases/istio.yaml
@@ -6,6 +6,10 @@ repositories:
   - name: "kubernetes-incubator"
     url: "https://kubernetes-charts-incubator.storage.googleapis.com"
 
+  # Cloud Posse incubator repo of helm charts
+  - name: "cloudposse-incubator"
+    url: "https://charts.cloudposse.com/incubator/"
+
 releases:
   #######################################################################################
   ## istio                                                                             ##


### PR DESCRIPTION
## what
1. [istio] Add missing `cloudposse-incubator` chart repo

## why
1. Required when installing by itself with the repo not pre-defined
