### PR TITLE
kubecost upgrade to v1.54.1

### DIFF
--- a/releases/kubecost.yaml
+++ b/releases/kubecost.yaml
@@ -27,7 +27,7 @@ releases:
       vendor: "kubecost"
       default: "false"
     chart: "kubecost/cost-analyzer"
-    version: "v1.46.6"
+    version: "v1.54.1"
     wait: true
     installed: {{ env "KUBECOST_INSTALLED" | default "true" }}
     values:


### PR DESCRIPTION
## what
1. [kubecost] upgraded to v1.54.1

## why
1. to Reduce Log Spam Overloading Elastic Search
