### PR TITLE
namespace_dashboards set to 'monitoring'

### DIFF
--- a/releases/kubecost.yaml
+++ b/releases/kubecost.yaml
@@ -49,6 +49,7 @@ releases:
             proxy: false
             {{ end }}
         grafana:
+          namespace_dashboards: "monitoring"
           sidecar:
             dashboards:
               enabled: true


### PR DESCRIPTION
## what
1. [kubecost] namespace_dashboards value set to 'monitoring'

## why
1. to override default value of `kubecost` to our standard `monitoring` namespace