### PR TITLE
istio logging can be configured now

### DIFF
--- a/releases/istio.yaml
+++ b/releases/istio.yaml
@@ -307,7 +307,7 @@ releases:
         # The control plane has different scopes depending on component, but can configure default log level across all components
         # If empty, default scope and level will be used as configured in code
         logging:
-          level: {{ env "ISTIO_LOGGING_LEVEL" | default "default:info" }}
+          level: {{ env "ISTIO_LOGGING_LEVEL" | default "default:info" | quote }}
 
         # monitoring port used by mixer, pilot, galley and sidecar injector
         monitoringPort: 15014

--- a/releases/istio.yaml
+++ b/releases/istio.yaml
@@ -307,7 +307,7 @@ releases:
         # The control plane has different scopes depending on component, but can configure default log level across all components
         # If empty, default scope and level will be used as configured in code
         logging:
-          level: "default:info"
+          level: {{ env "ISTIO_LOGGING_LEVEL" | default "default:info" }}
 
         # monitoring port used by mixer, pilot, galley and sidecar injector
         monitoringPort: 15014


### PR DESCRIPTION
## what
1. [istio] istio logging level can be configured using ISTIO_LOGGING_LEVEL env var

## why
1. to be able to make istio less verbose
