### PR TITLE
[istio-gatekeeper] set X-Forwarded-Proto=https

### DIFF
--- a/releases/istio-gatekeeper.yaml
+++ b/releases/istio-gatekeeper.yaml
@@ -130,6 +130,10 @@ releases:
       - enable-logging=true
       - verbose
       {{- end }}
+      {{- if and (eq (env "ISTIO_GATEKEEPER_TLS_ENABLED" | default "true") "true") (eq (env "ISTIO_GATEKEEPER_UPSTREAM_SCHEME" | default "https") "http") }}
+      - headers=X-Forwarded-Proto=https
+      - headers=X-Forwarded-Scheme=https
+      {{- end }}
     rbac:
       create: {{ env "RBAC_ENABLED" | default "false" }}
     serviceAccount:

--- a/releases/keycloak-gatekeeper.yaml
+++ b/releases/keycloak-gatekeeper.yaml
@@ -125,7 +125,6 @@ releases:
       {{- range $i, $rule := $service.rules }}
       - "{{ $rule }}"
       {{- end }}
-    {{- if index $service "extraArgs" }}
     extraArgs:
       # proxyTimeout must be in seconds to work with nginx,
       # but gatekeeper wants a golang Duration, so tack on "s"
@@ -136,10 +135,15 @@ releases:
       - upstream-expect-continue-timeout={{- $service.proxyTimeout -}}s
       - upstream-response-header-timeout={{- $service.proxyTimeout -}}s
       {{- end }}
+      ## If the internet side of the connection is HTTPS but the upstream is HTTP, you may want to add (via extraArgs)
+      # - headers=X-Forwarded-Proto=https
+      # - headers=X-Forwarded-Scheme=https
+      # "proto" is most common and usually enough, but some software only checks "scheme"
+      {{- if index $service "extraArgs" }}
       {{- range $i, $arg := $service.extraArgs }}
       - {{ $arg }}
       {{- end }}
-    {{- end }}
+      {{- end }}
     ### Optional: RBAC_ENABLED;
     rbac:
       create: {{ env "RBAC_ENABLED" | default "false" }}


### PR DESCRIPTION
## what
1. [istio-gatekeeper] set `X-Forwarded-Proto=https` and `X-Forwarded-Scheme=https` headers when front end is TLS and back end is not. 
1. [keycloak-gatekeeper] allow setting `proxyTimeout` even if no `extraArgs` are set

## why
1. Allow upstream service to determine if client is using HTTPS even if its connection is HTTP. 
1. bugfix
