### PR TITLE
[prometheus-operator] persistent storage for alertmanager

### DIFF
--- a/releases/prometheus-operator.yaml
+++ b/releases/prometheus-operator.yaml
@@ -290,7 +290,7 @@ releases:
         alertmanagerSpec:
           externalUrl: "{{- env "PROMETHEUS_ALERTMANAGER_EXTERNAL_URL" | default (print "https://api." (env "KOPS_CLUSTER_NAME") "/api/v1/namespaces/monitoring/services/prometheus-operator-alertmanager:web/proxy/") }}"
           {{- if env "PROMETHEUS_ALERTMANAGER_STORAGE_SIZE" }}
-          storageSpec:
+          storage:
             volumeClaimTemplate:
               spec:
                 {{- if env "PROMETHEUS_ALERTMANAGER_STORAGE_CLASS" }}


### PR DESCRIPTION
## what
1. [prometheus-operator] Persistent storage for `alertmanager`

## why
1. Allow Alertmanager to have persistent state
