### PR TITLE
Kiam version upgrade to version that supports IMDS v2

### DIFF
--- a/releases/kiam.yaml
+++ b/releases/kiam.yaml
@@ -154,6 +154,8 @@ releases:
           ### Optional: KIAM_SERVER_SERVICE_ACCOUNT_NAME;
           name: '{{ env "KIAM_SERVER_SERVICE_ACCOUNT_NAME" | default "" }}'
       agent:
+        image:
+          tag: "v3.6-rc1"
         gatewayTimeoutCreation: "5s"
         host:
           # IP tables must be set up on node independently of kiam in order to support rolling updates. See above.
@@ -176,6 +178,8 @@ releases:
           # in case you want to restrict access to one section of data.
           whitelist-route-regexp: '^/(latest/(meta-data|user-data|dynamic)|$)'
       server:
+        image:
+          tag: "v3.6-rc1"
         gatewayTimeoutCreation: "5s"
         sessionDuration: {{ env "KIAM_SERVER_SESSION_DURATION" | default "15m" }}
         nodeSelector:


### PR DESCRIPTION
## what
1. [kiam] Kiam 3.6-rc1 accepts by default requests to IMDSv2

## why
1. New versions of AWS SDK can use IMDSv2 which is blocked prior to `kiam` 3.6-rc0 version. This creates a lot of alarms based on `kiam_metadata_proxy_requests_blocked_total` which are false positives as clients can fallback to IMDSv1.

Ref:
- Instance Metadata Service Version 2 (IMDSv2)  https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html
- https://github.com/uswitch/kiam/issues/359 
- https://github.com/uswitch/kiam/pull/381

