### PR TITLE
[fluentd-kubernetes-aws] Change metrics names and improve alerts by introducing absent checks

### DIFF
--- a/releases/fluentd-elasticsearch-aws.yaml
+++ b/releases/fluentd-elasticsearch-aws.yaml
@@ -1,7 +1,7 @@
 repositories:
   # Cloud Posse incubator repo of helm charts
   - name: "cloudposse-incubator"
-    url: "git+https://charts.cloudposse.com/incubator/?ref=fluentd-alerting-on-new-metrics"
+    url: "https://charts.cloudposse.com/incubator/"
 
 releases:
 
@@ -24,7 +24,7 @@ releases:
       namespace: "monitoring"
       default: "false"
     chart: "cloudposse-incubator/fluentd-kubernetes-aws"
-    version: "0.1.0"
+    version: "0.2.0"
     wait: true
     installed: {{ env "FLUENTD_ELASTICSEARCH_AWS_INSTALLED" | default "true" }}
     values:

--- a/releases/fluentd-elasticsearch-aws.yaml
+++ b/releases/fluentd-elasticsearch-aws.yaml
@@ -1,7 +1,7 @@
 repositories:
   # Cloud Posse incubator repo of helm charts
   - name: "cloudposse-incubator"
-    url: "https://charts.cloudposse.com/incubator/"
+    url: "git+https://charts.cloudposse.com/incubator/?ref=fluentd-alerting-on-new-metrics"
 
 releases:
 


### PR DESCRIPTION
## What
* Reflect new metric names in alerts
* Added checks for absent metrics
* Change job to match `servicemonitor` configured

## Why
* Alerts were monitoring nonexistent metrics so they would never be triggered