### PR TITLE
[sentry] Sentry has new SENTRY_IMAGE_REPOSITORY variable

### DIFF
--- a/releases/sentry.yaml
+++ b/releases/sentry.yaml
@@ -30,7 +30,7 @@ releases:
     installed: {{ env "SENTRY_INSTALLED" | default "true" }}
     values:
       - image:
-          repository: "sentry"
+          repository: '{{ env "SENTRY_IMAGE_REPOSITORY" | default "sentry" }}'
           tag: '{{ env "SENTRY_IMAGE_TAG" | default "9.1.1" }}'
           pullPolicy: "IfNotPresent"
 


### PR DESCRIPTION
## what
1. [sentry] New variable SENTRY_IMAGE_REPOSITORY allowing to change default image repository

## why
1. Sentry 9 is not going to be develop further but we still want to support it. Thus using different image repository allows us to fix `sentry` issues.
