### PR TITLE
[pritunl] Add feature to expose multiple ports to pritunl

### DIFF
--- a/releases/pritunl.yaml
+++ b/releases/pritunl.yaml
@@ -59,11 +59,16 @@ releases:
         default:
           internal: 80
           external: 80
-      {{- range $i, $port := env "PRITUNL_VPN_PORT" | default "16807" | splitList "," }}
-        vpn{{ $i }}:
+        {{- range $i, $port := env "PRITUNL_VPN_PORT" | default "16807" | splitList "," }}
+        vpn-tcp-{{ $i }}:
           internal: {{ $port }}
           external: {{ $port }}
-      {{ end }}
+          protocol: TCP
+        vpn-udp-{{ $i }}:
+          internal: {{ $port }}
+          external: {{ $port }}
+          protocol: UDP
+        {{- end }}
 
     resources:
       limits:

--- a/releases/pritunl.yaml
+++ b/releases/pritunl.yaml
@@ -59,9 +59,11 @@ releases:
         default:
           internal: 80
           external: 80
-        vpn:
-          internal: {{ env "PRITUNL_VPN_PORT" | default "16807" }}
-          external: {{ env "PRITUNL_VPN_PORT" | default "16807" }}
+      {{- range $i, $port := env "PRITUNL_VPN_PORT" | default "16807" | splitList "," }}
+        vpn{{ $i }}:
+          internal: {{ $port }}
+          external: {{ $port }}
+      {{ end }}
 
     resources:
       limits:
@@ -93,7 +95,7 @@ releases:
         annotations:
           kubernetes.io/ingress.class: {{ env "PRITUNL_INGRESS_CLASS" | default "nginx" }}
         hosts:
-          {{ env "PRITUNL_UI_EXTERNAL_HOST" }}: /
+          {{ env "PRITUNL_UI_EXTERNAL_HOST" | default "pritunl" }}: /
           
 - name: pritunl-mongodb
   version: "5.3.4"

--- a/releases/pritunl.yaml
+++ b/releases/pritunl.yaml
@@ -100,8 +100,8 @@ releases:
         annotations:
           kubernetes.io/ingress.class: {{ env "PRITUNL_INGRESS_CLASS" | default "nginx" }}
         hosts:
-          {{ required "Must specify external host name for Ingress" (or (not (eq (env "PRITUNL_INGRESS_ENABLED") "true")) "PRITUNL_UI_EXTERNAL_HOST") }}: /
-          
+          {{ env "PRITUNL_UI_EXTERNAL_HOST" | default "pritunl" }}: /
+
 - name: pritunl-mongodb
   version: "5.3.4"
   chart: "stable/mongodb"

--- a/releases/pritunl.yaml
+++ b/releases/pritunl.yaml
@@ -95,7 +95,7 @@ releases:
         annotations:
           kubernetes.io/ingress.class: {{ env "PRITUNL_INGRESS_CLASS" | default "nginx" }}
         hosts:
-          {{ env "PRITUNL_UI_EXTERNAL_HOST" | default "pritunl" }}: /
+          {{ required "Must specify external host name for Ingress" (or (not (eq (env "PRITUNL_INGRESS_ENABLED") "true")) "PRITUNL_UI_EXTERNAL_HOST") }}: /
           
 - name: pritunl-mongodb
   version: "5.3.4"


### PR DESCRIPTION
## what
1. [pritunl] exposing multiple ports via variable that accepts comma delimited list of ports
2. [pritunl] fix variable without default, otherwise it was failing with
```
could not deduce `environment:` block, configuring only .Environment.Name. error: failed to read pritunl.yaml.part.0: reading document at index 1: yaml: line 95: did not find expected key
failed to read pritunl.yaml: reading document at index 1: yaml: line 95: did not find expected key
```

## why
1. so pritunl can serve multiple vpn configurations

Those changes are tested when PRITUNL_VPN_PORT was not configured, when it had the same value as default and for two ports.
Only change is that we need to enumerate services added. 