### PR TITLE
[prometheus-operator] alertmanager opsgenie integration

### DIFF
--- a/releases/prometheus-operator.yaml
+++ b/releases/prometheus-operator.yaml
@@ -296,6 +296,17 @@ releases:
                     firing: '{{"{{"}} template "pagerduty.default.firing" . {{"}}"}}'
                     resolved: '{{"{{"}} template "pagerduty.default.resolved" . {{"}}"}}'
               {{- end }}
+              {{- if not ( env "KUBE_PROMETHEUS_ALERT_MANAGER_OPSGENIE_API_KEY" | empty ) }}
+              opsgenie_configs:
+                - api_key: '{{ env "KUBE_PROMETHEUS_ALERT_MANAGER_OPSGENIE_API_KEY" | empty }}'
+                  send_resolved: true
+                  {{- if not ( env "NAMESPACE" | empty ) }}
+                  tags: '{{ env "NAMESPACE" | default "" }}'
+                  {{- end }}
+                  details:
+                    stage: '{{ env "STAGE" | default "N/A" }}'
+                    namespace: '{{ env "NAMESPACE" | default "N/A" }}'
+              {{- end }}
           templates:
             - ./*.tmpl
         alertmanagerSpec:


### PR DESCRIPTION
## what
1. [prometheus-operator] `alertmanager` can now be configured to send notifications to `opsgenie`

## why
1. to be able to integrate with `opsgenie`

## notes
- tested on single environment with and without variable `KUBE_PROMETHEUS_ALERT_MANAGER_OPSGENIE_API_KEY` ✅ 