### PR TITLE
Prometheus operator alertmanager opsgenie integration additional details

### DIFF
--- a/releases/prometheus-operator.yaml
+++ b/releases/prometheus-operator.yaml
@@ -300,9 +300,10 @@ releases:
               opsgenie_configs:
                 - api_key: '{{ env "KUBE_PROMETHEUS_ALERT_MANAGER_OPSGENIE_API_KEY" }}'
                   send_resolved: true
-                  {{- if not ( env "NAMESPACE" | empty ) }}
-                  tags: '{{ env "NAMESPACE" }}'
+                  {{- if not ( env "KUBE_PROMETHEUS_ALERT_MANAGER_OPSGENIE_MESSAGE" | empty ) }}
+                  message: '{{ env "KUBE_PROMETHEUS_ALERT_MANAGER_OPSGENIE_MESSAGE" }}'
                   {{- end }}
+                  tags: '{{ env "KUBE_PROMETHEUS_ALERT_MANAGER_OPSGENIE_TAGS" | default ` {{ range .CommonLabels.SortedPairs }}{{ .Name }}:{{ .Value }},{{ end }}`}}{{ env "STAGE" | default "N/A" }},{{ env "NAMESPACE" | default "N/A" }}'
                   details:
                     stage: '{{ env "STAGE" | default "N/A" }}'
                     namespace: '{{ env "NAMESPACE" | default "N/A" }}'


### PR DESCRIPTION
## what
1. [prometheus-operator] Additional opsgenie configuration that allows custom message
2. [prometheus-operator] Additional opsgenie configuration that adds all common labels to tags

## why
1. for opsgenie configuration to be more robust