### PR TITLE
update nginx-default-backend to 0.5.0

### DIFF
--- a/releases/nginx-ingress.yaml
+++ b/releases/nginx-ingress.yaml
@@ -29,7 +29,7 @@ releases:
     vendor: "kubernetes"
     default: "true"
   chart: "cloudposse-incubator/nginx-default-backend"
-  version: "0.4.0"
+  version: "0.5.0"
   wait: true
   installed: {{ env "NGINX_INGRESS_BACKEND_INSTALLED" | default "true" }}
   values:


### PR DESCRIPTION
## what
1. [nginx-ingress] nginx-default-backend to 0.5.0

## why
1. Newer Kubernetes version require selector to be present in DeploymentSpec. New version of chart provide it.

## references
* https://github.com/cloudposse/charts/pull/230
