### PR TITLE
Http2 anti-support

### DIFF
--- a/codefresh.yml
+++ b/codefresh.yml
@@ -13,7 +13,9 @@ steps:
     title: Build image
     type: build
     description: Build helmfiles
-    image_name: helmfiles
+    image_name: cloudposse/helmfiles
+    tag: '${{CF_REVISION}}'
+    registry: dockerhub
     dockerfile: Dockerfile
 
   semver:
@@ -27,19 +29,9 @@ steps:
     title: Push image with commit based semver tags
     type: push
     candidate: ${{build_image}}
+    registry: dockerhub
     tags:
       - "${{SEMVERSION_COMMIT_SHORT}}"
-
-  push_image_branch_to_cfcr:
-    title: Push image with branch based semver tags
-    type: push
-    candidate: ${{build_image}}
-    tags:
-      - "${{SEMVERSION_BRANCH_COMMIT_SHORT}}"
-    when:
-      condition:
-        all:
-          executeForBranch: "'${{SEMVERSION_BRANCH}}' != ''"
 
   push_image_branch_to_dockerhub:
     title: Push image with branch based semver tags
@@ -54,17 +46,6 @@ steps:
         all:
           executeForBranch: "'${{SEMVERSION_BRANCH}}' != ''"
 
-  push_image_tag_to_cfcr:
-    title: Push image with tag based semver tags
-    type: push
-    registry: cfcr
-    candidate: ${{build_image}}
-    tag: "${{SEMVERSION_TAG}}"
-    when:
-      condition:
-        all:
-          executeForTag: "'${{SEMVERSION_TAG}}' != ''"
-
   push_image_tag_to_dockerhub:
     title: Push image with tag based semver tags
     type: push
@@ -76,18 +57,6 @@ steps:
       condition:
         all:
           executeForTag: "'${{SEMVERSION_TAG}}' != ''"
-
-
-  push_image_latest_to_cfcf:
-    title: Push image with latest tag
-    type: push
-    registry: cfcr
-    candidate: ${{build_image}}
-    tag: latest
-    when:
-      condition:
-        all:
-          executeForMasterBranch: "'${{CF_BRANCH}}' == 'master'"
 
   push_image_latest_to_dockerhub:
     title: Push image with latest tag

--- a/releases/keycloak-gatekeeper.yaml
+++ b/releases/keycloak-gatekeeper.yaml
@@ -53,7 +53,7 @@ releases:
       pullPolicy: "IfNotPresent"
     debug: {{ index $service "debug" | default "false" }}
     replicas: {{ index $service "replicas" | default 1 }}
-    logging: false
+    logging: {{ index $service "debug" | default "false" }}
     sessionCookies: false
     droolsPolicyEnabled: false
     {{- if index $service "podAnnotations" }}

--- a/releases/nginx-ingress.yaml
+++ b/releases/nginx-ingress.yaml
@@ -94,6 +94,7 @@ releases:
         config:
           custom-http-errors: '{{ join "," $client_errors }},{{ join "," $server_errors }}'
           use-proxy-protocol: '{{ env "NGINX_INGRESS_USE_PROXY_PROTOCOL" | default "false" }}'
+          use-http2: '{{ env "NGINX_INGRESS_USE_HTTP2" | default "true" }}'
         service:
           externalTrafficPolicy: '{{ env "NGINX_INGRESS_EXTERNAL_TRAFFIC_POLICY" | default "Cluster" }}'
           annotations:


### PR DESCRIPTION
## what
1. [keycloak-gatekeeper] Include query logging when `debug: true`
1. [nginx-ingress] Add option to disable HTTP/2 support
1. Update Codefresh pipeline to remove references to obsolete `cfcr` repo

## why
1. When debugging issues with the proxy rather than with authentication, you need the query logs
1. Keycloak Gatekeeper (now louketo-proxy) has problems with HTTP/2 support. For example https://github.com/louketo/louketo-proxy/issues/575
1. Mandatory for Codefresh build to work