### PR TITLE
Upgrade some releases for helm v3

### DIFF
--- a/releases/cert-manager.yaml
+++ b/releases/cert-manager.yaml
@@ -102,7 +102,7 @@ releases:
     component: "iam"
     namespace: "cert-manager"
     default: "true"
-  version: "0.1.0"
+  version: "0.2.3"
   wait: true
   force: true
   recreatePods: true

--- a/releases/cluster-autoscaler.yaml
+++ b/releases/cluster-autoscaler.yaml
@@ -23,13 +23,15 @@ releases:
     namespace: "kube-system"
     vendor: "kubernetes"
   chart: "stable/cluster-autoscaler"
-  version: "6.0.0"
+  version: "7.3.4"
   wait: true
   installed: {{ env "CLUSTER_AUTOSCALER_INSTALLED" | default "true" }}
   values:
     - image:
         ### Optional: CLUSTER_AUTOSCALER_IMAGE_TAG;
-        tag: '{{ env "CLUSTER_AUTOSCALER_IMAGE_TAG" | default "v1.14.5" }}'
+        tag: '{{ env "CLUSTER_AUTOSCALER_IMAGE_TAG" | default "v1.17.3" }}'
+        ### Optional: CLUSTER_AUTOSCALER_IMAGE_REPOSITORY
+        repository: '{{ env "CLUSTER_AUTOSCALER_IMAGE_REPOSITORY" | default "k8s.gcr.io/autoscaling/cluster-autoscaler" }}'
       autoDiscovery:
         ### Required: KOPS_CLUSTER_NAME; e.g. cluster.k8s.local
         clusterName: '{{ env "KOPS_CLUSTER_NAME" }}'

--- a/releases/efs-provisioner.yaml
+++ b/releases/efs-provisioner.yaml
@@ -24,7 +24,7 @@ releases:
     vendor: "kubernetes"
     default: "false"
   chart: "stable/efs-provisioner"
-  version: "0.7.0"
+  version: "0.13.0"
   wait: true
   installed: {{ env "EFS_PROVISIONER_INSTALLED" | default "true" }}
   values:
@@ -32,7 +32,7 @@ releases:
         deployEnv: '{{ env "DEPLOY_ENV" | default "dev" }}'
       image:
         repository: '{{ env "EFS_PROVISIONER_IMAGE_REPOSITORY" | default "quay.io/external_storage/efs-provisioner" }}'
-        tag: '{{ env "EFS_PROVISIONER_IMAGE_TAG" | default "v2.2.0-k8s1.12" }}'
+        tag: '{{ env "EFS_PROVISIONER_IMAGE_TAG" | default "v2.4.0" }}'
         pullPolicy: "IfNotPresent"
       resources:
         limits:

--- a/releases/external-dns.yaml
+++ b/releases/external-dns.yaml
@@ -1,7 +1,6 @@
 repositories:
-# Stable repo of official helm charts
-- name: "stable"
-  url: "https://kubernetes-charts.storage.googleapis.com"
+- name: bitnami
+  url: https://charts.bitnami.com/bitnami
 
 releases:
 
@@ -22,8 +21,8 @@ releases:
     namespace: "kube-system"
     vendor: "kubernetes-incubator"
     default: "true"
-  chart: "stable/external-dns"
-  version: "2.7.0"
+  chart: "bitnami/external-dns"
+  version: "3.2.6"
   wait: true
   installed: {{ env "EXTERNAL_DNS_INSTALLED" | default "true" }}
   values:
@@ -70,5 +69,8 @@ releases:
         create: {{ env "RBAC_ENABLED" | default "false" }}
         ## Ignored if rbac.create is true
         ##
-        ### Optional: EXTERNAL_DNS_RBAC_SERVICE_ACCOUNT_NAME;
-        serviceAccountName: '{{ env "EXTERNAL_DNS_RBAC_SERVICE_ACCOUNT_NAME" | default "default" }}'
+      ### Optional: EXTERNAL_DNS_RBAC_SERVICE_ACCOUNT_NAME;
+      {{- if not (empty (env "EXTERNAL_DNS_RBAC_SERVICE_ACCOUNT_NAME")) }}
+      serviceAccount:
+        name: '{{ env "EXTERNAL_DNS_RBAC_SERVICE_ACCOUNT_NAME" }}'
+      {{- end }}

--- a/releases/fluentd-elasticsearch-aws.yaml
+++ b/releases/fluentd-elasticsearch-aws.yaml
@@ -24,7 +24,7 @@ releases:
       namespace: "monitoring"
       default: "false"
     chart: "cloudposse-incubator/fluentd-kubernetes-aws"
-    version: "0.2.0"
+    version: "0.2.1"
     wait: true
     installed: {{ env "FLUENTD_ELASTICSEARCH_AWS_INSTALLED" | default "true" }}
     values:
@@ -66,11 +66,13 @@ releases:
           FLUENT_ELASTICSEARCH_RECONNECT_ON_ERROR: true
           FLUENT_ELASTICSEARCH_RELOAD_ON_FAILURE: true
           FLUENT_ELASTICSEARCH_SSL_VERSION: "TLSv1_2"
+          # Settings for log throttling.
+          # See https://github.com/rubrikinc/fluent-plugin-throttle
           FLUENTD_THROTTLE_GROUP_KEY: '{{- env "FLUENTD_THROTTLE_GROUP_KEY" | default "kubernetes.pod_name" }}'
-          FLUENTD_THROTTLE_GROUP_BUCKET_PERIOD: '{{- env "FLUENTD_THROTTLE_GROUP_BUCKET_PERIOD" | default "600" }}'
-          FLUENTD_THROTTLE_GROUP_BUCKET_LIMIT: '{{- env "FLUENTD_THROTTLE_GROUP_BUCKET_LIMIT" | default "20000" }}'
-          FLUENTD_THROTTLE_GROUP_DROP_LOGS: '{{- env "FLUENTD_THROTTLE_GROUP_DROP_LOGS" | default "true" }}'
-          FLUENTD_THROTTLE_GROUP_RESET_RATE: '{{- env "FLUENTD_THROTTLE_GROUP_RESET_RATE" | default "33" }}'
+          FLUENTD_THROTTLE_GROUP_BUCKET_PERIOD: '{{- env "FLUENTD_THROTTLE_GROUP_BUCKET_PERIOD" | default "3" }}'
+          FLUENTD_THROTTLE_GROUP_BUCKET_LIMIT: '{{- env "FLUENTD_THROTTLE_GROUP_BUCKET_LIMIT" | default "300" }}'
+          FLUENTD_THROTTLE_GROUP_DROP_LOGS: '{{- env "FLUENTD_THROTTLE_GROUP_DROP_LOGS" | default "false" }}'
+          FLUENTD_THROTTLE_GROUP_RESET_RATE: '{{- env "FLUENTD_THROTTLE_GROUP_RESET_RATE" | default "-1" }}'
           FLUENTD_THROTTLE_GROUP_WARNING_DELAY: '{{- env "FLUENTD_THROTTLE_GROUP_WARNING_DELAY" | default "10" }}'
 
         resources:

--- a/releases/forecastle.yaml
+++ b/releases/forecastle.yaml
@@ -6,7 +6,8 @@ repositories:
     # v1.0.22: url: "git+https://github.com/stakater/Forecastle@deployments/kubernetes/chart?ref=8d6e5cd2dba3ad6c265ae94138c40276425b7634"
     # v1.0.25 url: "git+https://github.com/stakater/Forecastle@deployments/kubernetes/chart?ref=8f36b82beaf2a1a42b364a3857bc83638c51e30b"
     # v1.0.34 url: "git+https://github.com/stakater/Forecastle@deployments/kubernetes/chart?ref=19b369aa684152ad52c33d1935a74b0f425db2cb"
-    url: "git+https://github.com/stakater/Forecastle@deployments/kubernetes/chart?ref=19b369aa684152ad52c33d1935a74b0f425db2cb&sparse=0"
+    # v1.0.54 url: "git+https://github.com/stakater/Forecastle@deployments/kubernetes/chart?ref=febcb287ae120f091427ee186c82b87adf3b8410&sparse=0"
+    url: "git+https://github.com/stakater/Forecastle@deployments/kubernetes/chart?ref=febcb287ae120f091427ee186c82b87adf3b8410&sparse=0"
 
 releases:
 
@@ -17,7 +18,7 @@ releases:
 
   #
   # References:
-  #   - https://github.com/stakater/Forecastle/tree/v1.0.25/deployments/kubernetes/chart/forecastle
+  #   - https://github.com/stakater/Forecastle/tree/v1.0.54/deployments/kubernetes/chart/forecastle
   #   - https://github.com/stakater/Forecastle
   #
   - name: "forecastle"
@@ -29,25 +30,29 @@ releases:
       namespace: "kube-system"
       vendor: "stakater"
       default: "false"
+    # Requires Helmfile 0.125.0 or later
+    # chart: git::http://github.com/stakater/Forecastle.git@deployments/kubernetes/chart/forecastle?ref=v1.0.54
     chart: "forecastle/forecastle"
-    version: "v1.0.34"
+    version: "v1.0.54"
     wait: false
     installed: {{ env "FORECASTLE_INSTALLED" | default "true" }}
     force: true
-    recreatePods: true
+    # At some point we home Helmfile supports skipCrds
+    # skipCrds: {{ env "FORECASTLE_CREATE_CRD" | default "true" }}
     values:
       {{- if env "FORECASTLE_CUSTOM_APPS_YAML" }}
       - {{ env "FORECASTLE_CUSTOM_APPS_YAML" }}
       {{- end }}
       - forecastle:
-          createCustomResource: {{ env "FORECASTLE_CREATE_CRD" | default "true" }}
           image:
             pullPolicy: "IfNotPresent"
           namespace: '{{ env "FORECASTLE_NAMESPACE" | default "kube-system" }}'
           deployment:
-            # Some annotation is required or else we get a bunch of
-            # annotations from the default values.yaml
-            annotations: ""
+            # Helm 3 does not support "recreate pods" but Forecastle chart 1.0.54 does not
+            # support Pod template annotations. Using Reloader is our only hope until this is fixed.
+            # https://github.com/stakater/Forecastle/issues/121
+            annotations:
+              reloader.stakater.com/auto: "true"
             replicas: '{{- env "FORECASTLE_REPLICAS" | default "2" -}}'
             revisionHistoryLimit: '{{- env "FORECASTLE_REVISION_HISTORY_LIMIT" | default "10" -}}'
 
@@ -75,5 +80,4 @@ releases:
             #          icon: https://world
             #          group: Test
           service:
-            annotations: ""
             expose: "true"

--- a/releases/nginx-ingress.yaml
+++ b/releases/nginx-ingress.yaml
@@ -74,9 +74,10 @@ releases:
   values:
     - controller:
         image:
-          repository: "quay.io/kubernetes-ingress-controller/nginx-ingress-controller"
+          registry: '{{ env "NGINX_INGRESS_IMAGE_REGISTRY" | default "us.gcr.io" }}'
+          repository: '{{ env "NGINX_INGRESS_IMAGE_REPOSITORY" | default "k8s-artifacts-prod/ingress-nginx/controller" }}'
           ### Optional: NGINX_INGRESS_IMAGE_TAG; e.g. 0.25.1
-          tag: '{{ env "NGINX_INGRESS_IMAGE_TAG" | default "0.25.1" }}'
+          tag: '{{ env "NGINX_INGRESS_IMAGE_TAG" | default "v0.34.1" }}'
           pullPolicy: "IfNotPresent"
         ### Optional: NGINX_INGRESS_REPLICA_COUNT; Used only if `kind=Deployment` e.g. 4
         replicaCount: '{{ env "NGINX_INGRESS_REPLICA_COUNT" | default "4" }}'

--- a/releases/nginx-ingress.yaml
+++ b/releases/nginx-ingress.yaml
@@ -68,7 +68,7 @@ releases:
     vendor: "kubernetes"
     default: "true"
   chart: "stable/nginx-ingress"
-  version: "1.17.1"
+  version: "1.41.2"
   wait: true
   installed: {{ env "NGINX_INGRESS_INSTALLED" | default "true" }}
   values:


### PR DESCRIPTION
## what
1. [cert-manager] Update raw chart version
1. [cluster-autoscaler] Docker image repo moved
1. [efs-provisioner] Update to current chart and app
1. [external-dns] Helm stable deprecated, update to Bitnami chart, update to current version of chart and app
1. [fluentd-kubernetes-aws] Update chart (bugfix), default log throttling to warning only
1. [forecastle] Update to current
1. [nginx-ingress] Update to current chart and app

## why
1. Update to Helm charts compatible with Helm v3
1. Take this opportunity to update to current app as default

## Supersedes

- Closes #251 
- Closes #254 