### PR TITLE
Migrate Ingress APIs

### DIFF
--- a/releases/codefresh-account.yaml
+++ b/releases/codefresh-account.yaml
@@ -4,15 +4,17 @@ repositories:
   url: "https://charts.cloudposse.com/incubator/"
 
 ######
-# You need to create a codefresh-service-account-additional-rbac-rules.yaml file with an array RBAC rules,
+# You may want to to create a codefresh-service-account-additional-rbac-rules.yaml file with an array RBAC rules,
 # with values that do not use go templating, or you can use go templating
 # by adding `.gotmpl` to the end of the file name
 # See values/codefresh-service-account-additional-rbac-rules.yaml for an example
 #
+{{- if env "CODEFRESH_SERVICE_ACCOUNT_ADDITIONAL_RBAC_RULES" }}
 environments:
   default:
     values:
-      - {{ env "CODEFRESH_SERVICE_ACCOUNT_ADDITIONAL_RBAC_RULES" | default "codefresh-service-account-additional-rbac-rules.yaml" }}
+      - {{ env "CODEFRESH_SERVICE_ACCOUNT_ADDITIONAL_RBAC_RULES" }}
+{{- end }}
 
 releases:
 
@@ -48,15 +50,20 @@ releases:
         - apiGroups: [""]
           resources: ["*"]
           verbs: ["list", "watch", "get"]
+          # Under Helm version 3, Codefresh needs direct authority to
+          # make the changes specified in the Helm chart.
+        - apiGroups: [""]
+          resources: ["secrets","configmaps","services","persistentvolumes","persistentvolumeclaims"]
+          verbs: ["*"]
         - apiGroups: [""]
           resources: ["pods"]
           verbs: ["delete"]
         - apiGroups: ["extensions", "apps"]
-          resources: ["deployments", "replicasets"]
+          resources: ["deployments", "replicasets", "daemonsets", "statefulsets"]
           verbs: ["*"]
-        - apiGroups: ["extensions"]
+        - apiGroups: ["extensions", "networking.k8s.io"]
           resources: ["ingresses"]
-          verbs: ["get", "list"]
+          verbs: ["*"]
         - apiGroups: [""]
           resources: ["namespaces"]
 {{ if eq (env "CODEFRESH_SERVICE_ACCOUNT_UNLIMITED_STAGING_ENABLED" | default "false") "true" }}
@@ -66,11 +73,12 @@ releases:
 {{ end }}
         - apiGroups: ["storage.k8s.io"]
           resources: ["storageclasses"]
-          verbs: ["get", "list", "watch"]
+          verbs: ["*"]
         - apiGroups: [""]
           resources: ["pods/portforward"]
           verbs: ["create"]
-{{ with .Environment.Values.rules }}
+{{- if env "CODEFRESH_SERVICE_ACCOUNT_ADDITIONAL_RBAC_RULES" }}
+{{- with index .Environment.Values "rules" }}
 {{ toYaml . | indent 8 }}
-{{ end }}
-
+{{- end }}
+{{- end }}

--- a/releases/codefresh-extension.yaml
+++ b/releases/codefresh-extension.yaml
@@ -30,7 +30,7 @@ releases:
         clientId: {{ env "CODEFRESH_OIDC_CLIENT_ID" | b64enc }}
         clientSecret: {{ env "CODEFRESH_OIDC_CLIENT_SECRET" | b64enc }}
 {{ end }}
-    - apiVersion: extensions/v1beta1
+    - apiVersion: networking.k8s.io/v1beta1
       kind: Ingress
       metadata:
         namespace: codefresh
@@ -94,7 +94,7 @@ releases:
           secretName: cf-codefresh-star-selfsigned
 {{ end }}
 
-    - apiVersion: extensions/v1beta1
+    - apiVersion: networking.k8s.io/v1beta1
       kind: Ingress
       metadata:
         namespace: codefresh

--- a/releases/external-dns.yaml
+++ b/releases/external-dns.yaml
@@ -10,7 +10,8 @@ releases:
 
 #
 # References:
-#   - https://github.com/kubernetes/charts/blob/master/stable/external-dns/values.yaml
+#   - https://github.com/bitnami/charts/blob/master/bitnami/external-dns/values.yaml
+#   - https://github.com/bitnami/charts/blob/master/bitnami/external-dns/values-production.yaml
 #
 - name: "dns"
   namespace: "kube-system"
@@ -26,12 +27,27 @@ releases:
   wait: true
   installed: {{ env "EXTERNAL_DNS_INSTALLED" | default "true" }}
   values:
-    - sources:
+    - image:
+        {{- if env "EXTERNAL_DNS_IMAGE_REGISTRY" }}
+        registry: '{{ env "EXTERNAL_DNS_IMAGE_REGISTRY" }}'
+        {{- end }}
+        {{- if env "EXTERNAL_DNS_IMAGE_REPOSITORY" }}
+        repository: '{{ env "EXTERNAL_DNS_IMAGE_REPOSITORY" }}'
+        {{- end }}
+        {{- if env "EXTERNAL_DNS_IMAGE_TAG" }}
+        tag: '{{ env "EXTERNAL_DNS_IMAGE_TAG" }}'
+        {{- end }}
+        pullPolicy: '{{ env "EXTERNAL_DNS_IMAGE_PULL_POLICY" | default "IfNotPresent" }}'
+      sources:
       - service
       - ingress
-{{- if env "EXTERNAL_DNS_CRD_ENABLED" | default "false" | eq "true" }}
+      {{- if env "EXTERNAL_DNS_CRD_ENABLED" | default "false" | eq "true" }}
       - crd
-{{- end }}
+      {{- end }}
+
+      {{- if env "EXTERNAL_DNS_ANNOTATION_FILTER" }}
+      annotationFilter: '{{ env "EXTERNAL_DNS_ANNOTATION_FILTER" }}'
+      {{- end }}
       ### Required: EXTERNAL_DNS_TXT_OWNER_ID; e.g. us-west-2.staging.cloudposse.org
       txtOwnerId: '{{ env "EXTERNAL_DNS_TXT_OWNER_ID" }}'
       ### Required: EXTERNAL_DNS_TXT_PREFIX; e.g. 11591833-F9CE-407C-8519-35A947DB1D87-
@@ -40,11 +56,11 @@ releases:
       ### Optional: EXTERNAL_DNS_POLICY Modify (options: sync, upsert-only )
       policy:  '{{ env "EXTERNAL_DNS_POLICY" | default "sync" }}'
       provider: '{{ env "EXTERNAL_DNS_PROVIDER" | default "aws" }}'
-{{ if env "EXTERNAL_DNS_PROVIDER" | default "aws" | eq "cloudflare" }}
+      {{- if env "EXTERNAL_DNS_PROVIDER" | default "aws" | eq "cloudflare" }}
       cloudflare:
         apiKey: '{{ env "EXTERNAL_DNS_CLOUDFLARE_API_KEY" }}'
         email: '{{ env "EXTERNAL_DNS_CLOUDFLARE_EMAIL" }}'
-{{ end }}
+      {{- end }}
 
       podAnnotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"

--- a/releases/istio-gatekeeper.yaml
+++ b/releases/istio-gatekeeper.yaml
@@ -264,7 +264,7 @@ releases:
   installed: {{ env "ISTIO_GATEKEEPER_FORECASTLE_INSTALLED" | default "true" }}
   values:
     - resources:
-      - apiVersion: extensions/v1beta1
+      - apiVersion: networking.k8s.io/v1beta1
         kind: Ingress
         metadata:
           annotations:

--- a/releases/keycloak-gatekeeper.yaml
+++ b/releases/keycloak-gatekeeper.yaml
@@ -42,14 +42,17 @@ releases:
     vendor: "keycloak"
     default: "false"
   chart: "gabibbo97/keycloak-gatekeeper"
-  version: "1.2.1"
+  version: "3.3.1"
   wait: false
   installed: true
   values:
   - nameOverride: "key-gate-{{- $service.name }}"
     fullNameOverride: "key-gate-{{- $service.name }}"
     image:
-      tag: 6.0.1
+      {{- if (env "KEYCLOAK_GATEKEEPER_INGRESS_IMAGE_REPOSITORY") }}
+      repository: '{{ env "KEYCLOAK_GATEKEEPER_INGRESS_IMAGE_REPOSITORY" }}'
+      {{- end }}
+      tag: '{{ env "KEYCLOAK_GATEKEEPER_INGRESS_IMAGE_TAG" | default "9.0.3" }}'
       pullPolicy: "IfNotPresent"
     debug: {{ index $service "debug" | default "false" }}
     replicas: {{ index $service "replicas" | default 1 }}

--- a/releases/kibana-elastic-search.yaml
+++ b/releases/kibana-elastic-search.yaml
@@ -29,7 +29,7 @@ releases:
   installed: {{ env "KIBANA_ELASTICSEARCH_INSTALLED" | default "true" }}
   values:
   - resources:
-    - apiVersion: extensions/v1beta1
+    - apiVersion: networking.k8s.io/v1beta1
       kind: Ingress
       metadata:
         namespace: kube-system
@@ -45,7 +45,7 @@ releases:
                 serviceName: {{ env "KIBANA_INTERNAL_INGRESS_SERVICE" | default "traefik" }}
                 servicePort: {{ env "KIBANA_INTERNAL_INGRESS_SERVICE_PORT" | default "80" }}
               path: /
-    - apiVersion: extensions/v1beta1
+    - apiVersion: networking.k8s.io/v1beta1
       kind: Ingress
       metadata:
         namespace: kube-system

--- a/releases/oidc-ingress.yaml
+++ b/releases/oidc-ingress.yaml
@@ -57,14 +57,17 @@ releases:
     vendor: "keycloak"
     default: "true"
   chart: "gabibbo97/keycloak-gatekeeper"
-  version: "1.2.1"
+  version: "3.3.1"
   wait: false
   installed: {{ env "OIDC_INGRESS_INSTALLED" | default "true" }}
   values:
   - nameOverride: "oidc-ingress"
     fullNameOverride: "oidc-ingress"
     image:
-      tag: 6.0.1
+      {{- if (env "OIDC_INGRESS_IMAGE_REPOSITORY") }}
+      repository: '{{ env "OIDC_INGRESS_IMAGE_REPOSITORY" }}'
+      {{- end }}
+      tag: '{{ env "OIDC_INGRESS_IMAGE_TAG" | default "9.0.3" }}'
       pullPolicy: "IfNotPresent"
     debug: {{ env "OIDC_INGRESS_DEBUG" | default "false" }}
     replicas: {{ env "OIDC_INGRESS_REPLICAS" | default 1 }}
@@ -302,7 +305,7 @@ releases:
   installed: {{ env "OIDC_INGRESS_FORECASTLE_INSTALLED" | default "true" }}
   values:
   - resources:
-    - apiVersion: extensions/v1beta1
+    - apiVersion: networking.k8s.io/v1beta1
       kind: Ingress
       metadata:
         annotations:


### PR DESCRIPTION
## what

- [oidc-ingress] Upgrade to current Keycloak Gatekeeper chart and default to version 9.0.3
- [external-dns] Add `annotationFilter` setting (needed by oidc-ingress)
- Migrate Ingress API version from `extensions/v1beta1` to `networking.k8s.io/v1beta1` for the following Helmfiles:
   - [codefresh-extension]
   - [istio-gatekeeper]
   - [keycloak-gatekeeper]
   - [kibana-elastic-search]
   - [oidc-ingress]
- [codefresh-account] Update RBAC role to allow enhanced access needed by Helm version 3
## why
- API `extensions/v1beta1` is deprecated as of Kubernetes 1.16, which is the oldest currently supported Kubernetes
- [codefresh-account]  Under Helm version 2, the work of modifying the cluster was done by and under the authority of Tiller. Under Helm version 3, it is done under the authority of the helm user, so Codefresh needs a lot more authority.

## references

- https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/