### PR TITLE
Use atomic & cleanupOnFail

### DIFF
--- a/releases/cert-manager.yaml
+++ b/releases/cert-manager.yaml
@@ -32,6 +32,8 @@ releases:
   chart: "jetstack/cert-manager"
   version: "v0.9.0"
   wait: true
+  atomic: true
+  cleanupOnFail: true
   installed: {{ env "CERT_MANAGER_INSTALLED" | default "true" }}
   hooks:
     # This hoook adds the CRDs
@@ -104,7 +106,8 @@ releases:
     default: "true"
   version: "0.2.3"
   wait: true
-  force: true
+  atomic: true
+  cleanupOnFail: true
   recreatePods: true
   installed: {{ env "CERT_MANAGER_INSTALLED" | default "true" }}
   values:

--- a/releases/cert-manager.yaml
+++ b/releases/cert-manager.yaml
@@ -108,7 +108,6 @@ releases:
   wait: true
   atomic: true
   cleanupOnFail: true
-  recreatePods: true
   installed: {{ env "CERT_MANAGER_INSTALLED" | default "true" }}
   values:
   - resources:

--- a/releases/teleport-ent-auth.yaml
+++ b/releases/teleport-ent-auth.yaml
@@ -34,7 +34,8 @@ releases:
   version: "0.2.0"
   wait: true
   # atomic is not widely supported yet, but when it is, we should use it
-  # atomic: true
+  atomic: true
+  cleanupOnFail: true
   installed: {{ env "TELEPORT_AUTH_INSTALLED" | default "true" }}
   values:
   ## Configuration to be copied into Teleport container

--- a/releases/teleport-ent-proxy.yaml
+++ b/releases/teleport-ent-proxy.yaml
@@ -31,7 +31,8 @@ releases:
   chart: "cloudposse-incubator/teleport-ent-proxy"
   version: "0.4.0"
   wait: true
-  force: true
+  atomic: true
+  cleanupOnFail: true
   installed: {{ env "TELEPORT_PROXY_INSTALLED" | default "true" }}
   values:
   ## Configuration to be copied into Teleport container


### PR DESCRIPTION
## what
Remove `force: true` from, add `atomic: true`, `cleanupOnFail: true` to:
- [cert-manager]
- [teleport-ent-auth]
- [teleport-ent-proxy]

## why

- In general, `force: true` does not work with Services
- Better chance of leaving cluster in an operational state
