### PR TITLE
expose liveness and readiness values for controller

### DIFF
--- a/releases/nginx-ingress.yaml
+++ b/releases/nginx-ingress.yaml
@@ -78,7 +78,7 @@ releases:
           initialDelaySeconds: {{ env "NGINX_INGRESS_LIVENESS_PROBE_INITIAL_DELAY_SECONDS" | default 10 }}
           periodSeconds: {{ env "NGINX_INGRESS_LIVENESS_PROBE_PERIOD_SECONDS" | default 10 }}
           successThreshold: {{ env "NGINX_INGRESS_LIVENESS_PROBE_SUCCESS_THRESHOLD" | default 1 }}
-          timeoutSeconds: {{ env "NGINX_INGRESS_LIVENESS_PROBE_TIMEOUT_SECONDS" | default 1 }}
+          timeoutSeconds: {{ env "NGINX_INGRESS_LIVENESS_PROBE_TIMEOUT_SECONDS" | default 5 }}
           port: {{ env "NGINX_INGRESS_LIVENESS_PROBE_PORT" | default 10254 }}
         readinessProbe:
           failureThreshold: {{ env "NGINX_INGRESS_READINESS_PROBE_FAILURE_THRESHOLD" | default 3 }}

--- a/releases/nginx-ingress.yaml
+++ b/releases/nginx-ingress.yaml
@@ -73,6 +73,20 @@ releases:
   installed: {{ env "NGINX_INGRESS_INSTALLED" | default "true" }}
   values:
     - controller:
+        livenessProbe:
+          failureThreshold: {{ env "NGINX_INGRESS_LIVENESS_PROBE_FAILURE_THRESHOLD" | default 3 }}
+          initialDelaySeconds: {{ env "NGINX_INGRESS_LIVENESS_PROBE_INITIAL_DELAY_SECONDS" | default 10 }}
+          periodSeconds: {{ env "NGINX_INGRESS_LIVENESS_PROBE_PERIOD_SECONDS" | default 10 }}
+          successThreshold: {{ env "NGINX_INGRESS_LIVENESS_PROBE_SUCCESS_THRESHOLD" | default 1 }}
+          timeoutSeconds: {{ env "NGINX_INGRESS_LIVENESS_PROBE_TIMEOUT_SECONDS" | default 1 }}
+          port: {{ env "NGINX_INGRESS_LIVENESS_PROBE_PORT" | default 10254 }}
+        readinessProbe:
+          failureThreshold: {{ env "NGINX_INGRESS_READINESS_PROBE_FAILURE_THRESHOLD" | default 3 }}
+          initialDelaySeconds: {{ env "NGINX_INGRESS_READINESS_PROBE_INITIAL_DELAY_SECONDS" | default 10 }}
+          periodSeconds: {{ env "NGINX_INGRESS_READINESS_PROBE_PERIOD_SECONDS" | default 10 }}
+          successThreshold: {{ env "NGINX_INGRESS_READINESS_PROBE_SUCCESS_THRESHOLD" | default 1 }}
+          timeoutSeconds: {{ env "NGINX_INGRESS_READINESS_PROBE_TIMEOUT_SECONDS" | default 1 }}
+          port: {{ env "NGINX_INGRESS_READINESS_PROBE_PORT" | default 10254 }}
         image:
           registry: '{{ env "NGINX_INGRESS_IMAGE_REGISTRY" | default "us.gcr.io" }}'
           repository: '{{ env "NGINX_INGRESS_IMAGE_REPOSITORY" | default "k8s-artifacts-prod/ingress-nginx/controller" }}'


### PR DESCRIPTION
## what
1. [ingress-nginx] expose liveness and readiness values for controller

## why
1. needed to set the value of initialDelaySeconds for the liveness probe.
