### PR TITLE
[datadog] Update `datadog` helmfile

### DIFF
--- a/releases/datadog.yaml
+++ b/releases/datadog.yaml
@@ -13,6 +13,7 @@ releases:
   # DataDog official chart
   # https://github.com/helm/charts/tree/master/stable/datadog
   # https://docs.datadoghq.com/agent/kubernetes/helm/
+  # https://github.com/helm/charts/blob/master/stable/datadog/values.yaml
   - name: "datadog"
     namespace: "monitoring"
     labels:
@@ -22,7 +23,7 @@ releases:
       namespace: "monitoring"
       vendor: "datadog"
     chart: "stable/datadog"
-    version: { { env "DATADOG_CHART_VERSION" | default "2.3.42" } }
+    version: '{ { env "DATADOG_CHART_VERSION" | default "2.3.42" } }'
     wait: true
     timeout: { { env "DATADOG_APPLY_TIMEOUT" | default "1800" } }
     atomic: true
@@ -31,9 +32,9 @@ releases:
     createNamespace: { { env "DATADOG_CREATE_NAMESPACE" | default "true" } }
     values:
       - datadog:
-          apiKey: { { env "DATADOG_API_KEY" } }
-          appKey: { { env "DATADOG_APP_KEY" } }
-          logLevel: { { env "DATADOG_LOG_LEVEL" | default "INFO" } }
+          apiKey: '{ { env "DATADOG_API_KEY" } }'
+          appKey: '{ { env "DATADOG_APP_KEY" } }'
+          logLevel: '{ { env "DATADOG_LOG_LEVEL" | default "INFO" } }'
           logs:
             enabled: { { env "DATADOG_LOGS_ENABLED" | default "false" } }
             containerCollectAll: { { env "DATADOG_LOGS_CONTAINER_COLLECT_ALL" | default "false" } }
@@ -41,7 +42,7 @@ releases:
             enabled: { { env "DATADOG_APM_ENABLED" | default "false" } }
           processAgent:
             enabled: { { env "DATADOG_PROCESS_AGENT_ENABLED" | default "false" } }
-            processCollection: { { env "DATADOG_PROCESS_AGENT_PROCESS_COLLECTION" | default "false" } }
+            processCollection: { { env "DATADOG_PROCESS_AGENT_PROCESS_COLLECTION_ENABLED" | default "false" } }
           systemProbe:
             enabled: { { env "DATADOG_SYSTEM_PROBE_ENABLED" | default "false" } }
           kubeStateMetricsEnabled: { { env "DATADOG_KUBE_STATE_METRICS_ENABLED" | default "true" } }

--- a/releases/datadog.yaml
+++ b/releases/datadog.yaml
@@ -56,3 +56,9 @@ releases:
               enabled: {{ env "DATADOG_CLUSTER_AGENT_CLUSTER_CHECKS_ENABLED" | default "true" }}
           collectEvents: {{ env "DATADOG_COLLECT_EVENTS_ENABLED" | default "true" }}
           leaderElection: {{ env "DATADOG_LEADER_ELECTION_ENABLED" | default "true" }}
+{{- if env "DATADOG_TAGS" }}
+          tags:
+{{- with env "DATADOG_TAGS" }}
+{{ toYaml . | indent 12 }}
+{{- end }}
+{{- end }}

--- a/releases/datadog.yaml
+++ b/releases/datadog.yaml
@@ -1,29 +1,25 @@
 repositories:
-  # Stable repo of official helm charts
-  - name: "stable"
-    url: "https://kubernetes-charts.storage.googleapis.com"
+  - name: "datadog"
+    url: "https://helm.datadoghq.com"
 
 releases:
 
-  #######################################################################################
-  ## datadog                                                                           ##
-  ## Datadog is a hosted infrastructure monitoring platform                            ##
-  #######################################################################################
-
-  # DataDog official chart
+  # Datadog is a hosted infrastructure monitoring platform
+  # https://github.com/DataDog/helm-charts
   # https://github.com/helm/charts/tree/master/stable/datadog
   # https://docs.datadoghq.com/agent/kubernetes/helm/
   # https://github.com/helm/charts/blob/master/stable/datadog/values.yaml
+
   - name: "datadog"
     namespace: "monitoring"
     labels:
       chart: "datadog"
-      repo: "stable"
+      repo: "datadog"
       component: "datadog"
       namespace: "monitoring"
       vendor: "datadog"
-    chart: "stable/datadog"
-    version: '{{ env "DATADOG_CHART_VERSION" | default "2.3.42" }}'
+    chart: "datadog/datadog"
+    version: '{{ env "DATADOG_CHART_VERSION" | default "2.4.24" }}'
     wait: true
     timeout: {{ env "DATADOG_APPLY_TIMEOUT" | default "180" }}
     atomic: true

--- a/releases/datadog.yaml
+++ b/releases/datadog.yaml
@@ -32,6 +32,7 @@ releases:
     createNamespace: {{ env "DATADOG_CREATE_NAMESPACE" | default "true" }}
     values:
       - datadog:
+          clusterName: '{{ env "DATADOG_CLUSTER_NAME" }}'
           apiKey: '{{ env "DATADOG_API_KEY" }}'
           appKey: '{{ env "DATADOG_APP_KEY" }}'
           logLevel: '{{ env "DATADOG_LOG_LEVEL" | default "INFO" }}'

--- a/releases/datadog.yaml
+++ b/releases/datadog.yaml
@@ -25,7 +25,7 @@ releases:
     chart: "stable/datadog"
     version: '{ { env "DATADOG_CHART_VERSION" | default "2.3.42" } }'
     wait: true
-    timeout: { { env "DATADOG_APPLY_TIMEOUT" | default "1800" } }
+    timeout: { { env "DATADOG_APPLY_TIMEOUT" | default "180" } }
     atomic: true
     cleanupOnFail: true
     installed: { { env "DATADOG_INSTALLED" | default "true" } }

--- a/releases/datadog.yaml
+++ b/releases/datadog.yaml
@@ -23,35 +23,35 @@ releases:
       namespace: "monitoring"
       vendor: "datadog"
     chart: "stable/datadog"
-    version: '{ { env "DATADOG_CHART_VERSION" | default "2.3.42" } }'
+    version: '{{ env "DATADOG_CHART_VERSION" | default "2.3.42" }}'
     wait: true
-    timeout: { { env "DATADOG_APPLY_TIMEOUT" | default "180" } }
+    timeout: {{ env "DATADOG_APPLY_TIMEOUT" | default "180" }}
     atomic: true
     cleanupOnFail: true
-    installed: { { env "DATADOG_INSTALLED" | default "true" } }
-    createNamespace: { { env "DATADOG_CREATE_NAMESPACE" | default "true" } }
+    installed: {{ env "DATADOG_INSTALLED" | default "true" }}
+    createNamespace: {{ env "DATADOG_CREATE_NAMESPACE" | default "true" }}
     values:
       - datadog:
-          apiKey: '{ { env "DATADOG_API_KEY" } }'
-          appKey: '{ { env "DATADOG_APP_KEY" } }'
-          logLevel: '{ { env "DATADOG_LOG_LEVEL" | default "INFO" } }'
+          apiKey: '{{ env "DATADOG_API_KEY" }}'
+          appKey: '{{ env "DATADOG_APP_KEY" }}'
+          logLevel: '{{ env "DATADOG_LOG_LEVEL" | default "INFO" }}'
           logs:
-            enabled: { { env "DATADOG_LOGS_ENABLED" | default "false" } }
-            containerCollectAll: { { env "DATADOG_LOGS_CONTAINER_COLLECT_ALL" | default "false" } }
+            enabled: {{ env "DATADOG_LOGS_ENABLED" | default "false" }}
+            containerCollectAll: {{ env "DATADOG_LOGS_CONTAINER_COLLECT_ALL" | default "false" }}
           apm:
-            enabled: { { env "DATADOG_APM_ENABLED" | default "false" } }
+            enabled: {{ env "DATADOG_APM_ENABLED" | default "false" }}
           processAgent:
-            enabled: { { env "DATADOG_PROCESS_AGENT_ENABLED" | default "false" } }
-            processCollection: { { env "DATADOG_PROCESS_AGENT_PROCESS_COLLECTION_ENABLED" | default "false" } }
+            enabled: {{ env "DATADOG_PROCESS_AGENT_ENABLED" | default "false" }}
+            processCollection: {{ env "DATADOG_PROCESS_AGENT_PROCESS_COLLECTION_ENABLED" | default "false" }}
           systemProbe:
-            enabled: { { env "DATADOG_SYSTEM_PROBE_ENABLED" | default "false" } }
-          kubeStateMetricsEnabled: { { env "DATADOG_KUBE_STATE_METRICS_ENABLED" | default "true" } }
+            enabled: {{ env "DATADOG_SYSTEM_PROBE_ENABLED" | default "false" }}
+          kubeStateMetricsEnabled: {{ env "DATADOG_KUBE_STATE_METRICS_ENABLED" | default "true" }}
           clusterAgent:
-            enabled: { { env "DATADOG_CLUSTER_AGENT_ENABLED" | default "true" } }
-            replicas: { { env "DATADOG_CLUSTER_AGENT_REPLICA_COUNT" | default "1" } }
+            enabled: {{ env "DATADOG_CLUSTER_AGENT_ENABLED" | default "true" }}
+            replicas: {{ env "DATADOG_CLUSTER_AGENT_REPLICA_COUNT" | default "1" }}
             metricsProvider:
-              enabled: { { env "DATADOG_CLUSTER_AGENT_METRICS_PROVIDER_ENABLED" | default "false" } }
+              enabled: {{ env "DATADOG_CLUSTER_AGENT_METRICS_PROVIDER_ENABLED" | default "false" }}
             clusterChecks:
-              enabled: { { env "DATADOG_CLUSTER_AGENT_CLUSTER_CHECKS_ENABLED" | default "true" } }
-          collectEvents: { { env "DATADOG_COLLECT_EVENTS_ENABLED" | default "true" } }
-          leaderElection: { { env "DATADOG_LEADER_ELECTION_ENABLED" | default "true" } }
+              enabled: {{ env "DATADOG_CLUSTER_AGENT_CLUSTER_CHECKS_ENABLED" | default "true" }}
+          collectEvents: {{ env "DATADOG_COLLECT_EVENTS_ENABLED" | default "true" }}
+          leaderElection: {{ env "DATADOG_LEADER_ELECTION_ENABLED" | default "true" }}

--- a/releases/datadog.yaml
+++ b/releases/datadog.yaml
@@ -56,9 +56,10 @@ releases:
               enabled: {{ env "DATADOG_CLUSTER_AGENT_CLUSTER_CHECKS_ENABLED" | default "true" }}
           collectEvents: {{ env "DATADOG_COLLECT_EVENTS_ENABLED" | default "true" }}
           leaderElection: {{ env "DATADOG_LEADER_ELECTION_ENABLED" | default "true" }}
-{{- if env "DATADOG_TAGS" }}
+          # https://docs.datadoghq.com/getting_started/tagging/
+          {{- if env "DATADOG_TAGS" }}
           tags:
-{{- with env "DATADOG_TAGS" }}
-{{ toYaml . | indent 12 }}
-{{- end }}
-{{- end }}
+            {{- range $i, $tag := ( (env "DATADOG_TAGS") | splitList "," ) }}
+            - "{{ $tag }}"
+            {{- end }}
+          {{- end }}

--- a/releases/datadog.yaml
+++ b/releases/datadog.yaml
@@ -1,95 +1,56 @@
 repositories:
-# Stable repo of official helm charts
-- name: "stable"
-  url: "https://kubernetes-charts.storage.googleapis.com"
+  # Stable repo of official helm charts
+  - name: "stable"
+    url: "https://kubernetes-charts.storage.googleapis.com"
 
 releases:
 
-#######################################################################################
-## datadog                                                                           ##
-## Datadog is a hosted infrastructure monitoring platform                            ##
-#######################################################################################
+  #######################################################################################
+  ## datadog                                                                           ##
+  ## Datadog is a hosted infrastructure monitoring platform                            ##
+  #######################################################################################
 
-#
-# References:
-#   - https://github.com/helm/charts/tree/master/stable/datadog
-#   - https://github.com/helm/charts/blob/master/stable/datadog/values.yaml
-#
-- name: "datadog"
-  namespace: "monitoring"
-  labels:
-    chart: "datadog"
-    repo: "stable"
-    component: "monitoring"
+  # DataDog official chart
+  # https://github.com/helm/charts/tree/master/stable/datadog
+  # https://docs.datadoghq.com/agent/kubernetes/helm/
+  - name: "datadog"
     namespace: "monitoring"
-    vendor: "datadog"
-    default: "false"
-  chart: "stable/datadog"
-  version: "1.22.0"
-  wait: true
-  installed: {{ env "DATADOG_INSTALLED" | default "true" }}
-  values:
-    - image:
-        repository: "datadog/agent"
-        ### Optional: DATADOG_IMAGE_TAG; e.g. 6.1.2
-        ### Version of datadog agent from https://hub.docker.com/r/datadog/agent/tags/
-        tag: '{{ env "DATADOG_IMAGE_TAG" | default "latest" }}'
-        pullPolicy: "IfNotPresent"
-      datadog:
-        ### Required: DATADOG_API_KEY;
-        apiKey: '{{ requiredEnv "DATADOG_API_KEY" }}'
-{{ if env "DATADOG_CLUSTER_AGENT_ENABLED" | default "false" | eq "true" }}
-        appKey: '{{ requiredEnv "DATADOG_APP_KEY" }}'
-{{ else if env "RBAC_ENABLED" | default "false" | eq "true" }}        
-        collectEvents: {{ env "DATADOG_COLLECT_EVENTS" | default "true" }}
-        # leaderElection is required if collectEvents: true
-        leaderElection: {{ env "DATADOG_COLLECT_EVENTS" | default "true" }}
-{{ end }}
-        ### Optional: DATADOG_APM_ENABLED; e.g. true
-        apmEnabled: {{ env "DATADOG_APM_ENABLED" | default "false" }}
-        ### Optional Live Process monitoring https://docs.datadoghq.com/graphing/infrastructure/process/
-        processAgentEnabled: {{ env "DATADOG_PROCESS_AGENT_ENABLED" | default "false" }}
-{{ if env "DATADOG_TAG_WITH_CLUSTER_NAME" | default "false" }}   
-        tags: 'cluster:{{ requiredEnv "KOPS_CLUSTER_NAME" }}' 
-{{ end }}
-        resources:
-          limits:
-            cpu: "256m"
-            memory: "512Mi"
-          requests:
-            cpu: "50m"
-            memory: "128Mi"
-      clusterAgent:
-        enabled: {{ env "DATADOG_CLUSTER_AGENT_ENABLED" | default "false" }}
-        repository: "datadog/cluster-agent"
-        image:
-          ### Version of cluster agent from https://hub.docker.com/r/datadog/cluster-agent/tags
-          tag: {{ env "DATADOG_CLUSTER_AGENT_IMAGE_TAG" | default "latest" }}
-        # token: A cluster-internal secret for agent-to-agent communication. Must be 32+ characters a-zA-Z
-        token: {{ env "DATADOG_CLUSTER_AGENT_TOKEN" }}
-        resources:
-          limits:
-            cpu: "256m"
-            memory: "512Mi"
-          requests:
-            cpu: "50m"
-            memory: "32Mi"
-      rbac:
-        ### Optional: RBAC_ENABLED;
-        create: {{ env "RBAC_ENABLED" | default "false" }}
-        ### Optional: DATADOG_RBAC_SERVICE_ACCOUNT_NAME;
-        serviceAccountName: '{{ env "DATADOG_RBAC_SERVICE_ACCOUNT_NAME" | default "default" }}'
-      kube-state-metrics:
-        rbac:
-          ### Optional: RBAC_ENABLED;
-          create: {{ env "RBAC_ENABLED" | default "false" }}
-          ### Optional: DATADOG_KUBE_STATE_METRICS_RBAC_SERVICE_ACCOUNT_NAME;
-          serviceAccountName: '{{ env "DATADOG_KUBE_STATE_METRICS_RBAC_SERVICE_ACCOUNT_NAME" | default "default" }}'
-      daemonset:
-        ### Optional: DATADOG_USE_HOST_PORT; e.g. false
-        useHostPort: {{ env "DATADOG_USE_HOST_PORT" | default "true" }}
-        ### Optional: DATADOG_UPDATE_STRATEGY; e.g. RollingUpdate
-        updateStrategy: '{{ env "DATADOG_UPDATE_STRATEGY" | default "OnDelete" }}'
-        tolerations:
-          - key: node-role.kubernetes.io/master
-            effect: NoSchedule
+    labels:
+      chart: "datadog"
+      repo: "stable"
+      component: "datadog"
+      namespace: "monitoring"
+      vendor: "datadog"
+    chart: "stable/datadog"
+    version: { { env "DATADOG_CHART_VERSION" | default "2.3.42" } }
+    wait: true
+    timeout: { { env "DATADOG_APPLY_TIMEOUT" | default "1800" } }
+    atomic: true
+    cleanupOnFail: true
+    installed: { { env "DATADOG_INSTALLED" | default "true" } }
+    createNamespace: { { env "DATADOG_CREATE_NAMESPACE" | default "true" } }
+    values:
+      - datadog:
+          apiKey: { { env "DATADOG_API_KEY" } }
+          appKey: { { env "DATADOG_APP_KEY" } }
+          logLevel: { { env "DATADOG_LOG_LEVEL" | default "INFO" } }
+          logs:
+            enabled: { { env "DATADOG_LOGS_ENABLED" | default "false" } }
+            containerCollectAll: { { env "DATADOG_LOGS_CONTAINER_COLLECT_ALL" | default "false" } }
+          apm:
+            enabled: { { env "DATADOG_APM_ENABLED" | default "false" } }
+          processAgent:
+            enabled: { { env "DATADOG_PROCESS_AGENT_ENABLED" | default "false" } }
+            processCollection: { { env "DATADOG_PROCESS_AGENT_PROCESS_COLLECTION" | default "false" } }
+          systemProbe:
+            enabled: { { env "DATADOG_SYSTEM_PROBE_ENABLED" | default "false" } }
+          kubeStateMetricsEnabled: { { env "DATADOG_KUBE_STATE_METRICS_ENABLED" | default "true" } }
+          clusterAgent:
+            enabled: { { env "DATADOG_CLUSTER_AGENT_ENABLED" | default "true" } }
+            replicas: { { env "DATADOG_CLUSTER_AGENT_REPLICA_COUNT" | default "1" } }
+            metricsProvider:
+              enabled: { { env "DATADOG_CLUSTER_AGENT_METRICS_PROVIDER_ENABLED" | default "false" } }
+            clusterChecks:
+              enabled: { { env "DATADOG_CLUSTER_AGENT_CLUSTER_CHECKS_ENABLED" | default "true" } }
+          collectEvents: { { env "DATADOG_COLLECT_EVENTS_ENABLED" | default "true" } }
+          leaderElection: { { env "DATADOG_LEADER_ELECTION_ENABLED" | default "true" } }

--- a/releases/datadog.yaml
+++ b/releases/datadog.yaml
@@ -6,9 +6,8 @@ releases:
 
   # Datadog is a hosted infrastructure monitoring platform
   # https://github.com/DataDog/helm-charts
-  # https://github.com/helm/charts/tree/master/stable/datadog
   # https://docs.datadoghq.com/agent/kubernetes/helm/
-  # https://github.com/helm/charts/blob/master/stable/datadog/values.yaml
+  # https://github.com/DataDog/helm-charts/blob/master/charts/datadog/values.yaml
 
   - name: "datadog"
     namespace: "monitoring"


### PR DESCRIPTION
## what
* [datadog] Update `datadog` helmfile

## why
* Bring the helmfile up to date
* The official Datadog chart is now in a new repo https://github.com/DataDog/helm-charts. The old one https://github.com/helm/charts/tree/master/stable/datadog is deprecated.

## test

```
Upgrading release=datadog, chart=datadog/datadog
Release "datadog" has been upgraded. Happy Helming!
NAME: datadog
LAST DEPLOYED: Fri Oct  2 05:09:22 2020
NAMESPACE: monitoring
STATUS: deployed
REVISION: 6
TEST SUITE: None
NOTES:
Datadog agents are spinning up on each node in your cluster. After a few
minutes, you should see your agents starting in your event stream:
    https://app.datadoghq.com/event/stream
The Datadog Agent is listening on port 8126 for APM service.

Listing releases matching ^datadog$
datadog	monitoring	6       	2020-10-02 05:09:22.7779288 +0000 UTC	deployed	datadog-2.4.24	7


UPDATED RELEASES:
NAME      CHART             VERSION
datadog   datadog/datadog    2.4.24
```
