### PR TITLE
[deprecated/cert-manager] Upgrade to GA

### DIFF
--- a/deprecated/cert-manager.yaml
+++ b/deprecated/cert-manager.yaml
@@ -37,6 +37,15 @@ releases:
   createNamespace: true
   installed: {{ env "CERT_MANAGER_INSTALLED" | default "true" }}
   hooks:
+  - events: ["presync"]
+    showlogs: true
+    command: "/bin/sh"
+    args:
+    - "-c"
+    - >-
+      [[ "{{`{{ .Release.Namespace }}`}}" = "cert-manager" ]] && [[ -n "${CERT_MANAGER_IAM_ROLE}" ]]
+      && kubectl annotate namespace "{{`{{ .Release.Namespace }}`}}" "iam.amazonaws.com/permitted=${CERT_MANAGER_IAM_ROLE}"
+      || echo + Not annotating namespace "{{`{{ .Release.Namespace }}`}}" with "iam.amazonaws.com/permitted=${CERT_MANAGER_IAM_ROLE}"
   - events: ["postsync"]
     # Give cert-manager time to initialize itself
     showlogs: true

--- a/deprecated/cert-manager.yaml
+++ b/deprecated/cert-manager.yaml
@@ -16,9 +16,9 @@ releases:
 
 #
 # References:
-# - https://github.com/jetstack/cert-manager/blob/v0.9.0/deploy/charts/cert-manager/values.yaml
+# - https://github.com/jetstack/cert-manager/blob/v1.0.4/deploy/charts/cert-manager/values.yaml
 # Instructions for installing and testing correct install are at
-# - https://docs.cert-manager.io/en/release-0.9/getting-started/install/kubernetes.html
+# - https://cert-manager.io/docs/installation/kubernetes/#installing-with-helm
 #
 - name: "cert-manager"
   namespace: "cert-manager"
@@ -30,31 +30,21 @@ releases:
     vendor: "jetstack"
     default: "false"
   chart: "jetstack/cert-manager"
-  version: "v0.9.0"
+  version: "{{ env "CERT_MANAGER_CHART_VERSION" | default "v1.0.4" }}"
   wait: true
   atomic: true
   cleanupOnFail: true
+  createNamespace: true
   installed: {{ env "CERT_MANAGER_INSTALLED" | default "true" }}
   hooks:
-    # This hoook adds the CRDs
-    - events: ["presync"]
-      showlogs: true
-      command: "/bin/sh"
-      args: ["-c", "kubectl apply -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.9/deploy/manifests/00-crds.yaml"]
-    # This hook adds the annotation that keeps the webhook from preventing its own installation
-    - events: ["presync"]
-      showlogs: true
-      command: "/bin/sh"
-      args:
-      - "-c"
-      - >-
-        kubectl get namespace "{{`{{ .Release.Namespace }}`}}" >/dev/null 2>&1 || kubectl create namespace "{{`{{ .Release.Namespace }}`}}";
-        kubectl label --overwrite namespace "{{`{{ .Release.Namespace }}`}}" "certmanager.k8s.io/disable-validation=true" ;
-        [[ "{{`{{ .Release.Namespace }}`}}" = "cert-manager" ]] && [[ -n "${CERT_MANAGER_IAM_ROLE}" ]]
-        && kubectl annotate namespace "{{`{{ .Release.Namespace }}`}}" "iam.amazonaws.com/permitted=${CERT_MANAGER_IAM_ROLE}"
-        || echo + Not annotating namespace "{{`{{ .Release.Namespace }}`}}" with "iam.amazonaws.com/permitted=${CERT_MANAGER_IAM_ROLE}"
+  - events: ["postsync"]
+    # Give cert-manager time to initialize itself
+    showlogs: true
+    command: "/bin/sleep"
+    args: ["15"]
   values:
     - fullnameOverride: cert-manager
+      installCRDs: true
       rbac:
         ### Optional: RBAC_ENABLED;
         create: {{ env "RBAC_ENABLED" | default "false" }}
@@ -67,20 +57,20 @@ releases:
         # defaultIssuerKind: ""
         # defaultACMEChallengeType: ""
         # defaultACMEDNS01ChallengeProvider: ""
-{{ if env "CERT_MANAGER_IAM_ROLE" | default "" }}
+      {{- if env "CERT_MANAGER_IAM_ROLE" | default "" }}
       podAnnotations:
         ### Required: EXTERNAL_DNS_IAM_ROLE; e.g. cp-staging-external-dns
         iam.amazonaws.com/role: '{{ env "CERT_MANAGER_IAM_ROLE" }}'
-{{ end }}
+      {{- end }}
       serviceAccount:
         ### Optional: RBAC_ENABLED;
         create: {{ env "RBAC_ENABLED" | default "false" }}
         ### Optional: CERT_MANAGER_SERVICE_ACCOUNT_NAME;
         name: '{{ env "CERT_MANAGER_SERVICE_ACCOUNT_NAME" | default "" }}'
       prometheus:
-        enabled: true
+        enabled: {{ env "CERT_MANAGER_METRICS_ENABLED" | default (env "METRICS_ENABLED") | default "false" }}
         servicemonitor:
-          enabled: true
+          enabled: {{ env "CERT_MANAGER_METRICS_ENABLED" | default (env "METRICS_ENABLED") | default "false" }}
           prometheusInstance: default
           targetPort: 9402
           path: /metrics
@@ -98,10 +88,11 @@ releases:
           cpu: "50m"
           memory: "128Mi"
 - name: 'cert-manager-issuers'
+  needs: ['cert-manager/cert-manager']
   chart: "kubernetes-incubator/raw"
   namespace: "cert-manager"
   labels:
-    component: "iam"
+    component: "cert-manager"
     namespace: "cert-manager"
     default: "true"
   version: "0.2.3"
@@ -109,9 +100,10 @@ releases:
   atomic: true
   cleanupOnFail: true
   installed: {{ env "CERT_MANAGER_INSTALLED" | default "true" }}
+  disableValidation: true
   values:
   - resources:
-    - apiVersion: certmanager.k8s.io/v1alpha1
+    - apiVersion: cert-manager.io/v1
       kind: ClusterIssuer
       metadata:
         name: letsencrypt-staging
@@ -125,16 +117,19 @@ releases:
           privateKeySecretRef:
             name: letsencrypt-staging
           solvers:
+            {{- if env "CERT_MANAGER_HTTP_SOLVER_ENABLED" | default "" }}
             # Enable the HTTP-01 challenge provider
             - http01:
                 ingress:
                   class: nginx
-{{- if env "CERT_MANAGER_IAM_ROLE" | default "" }}
+            {{- end }}
+            {{- if env "CERT_MANAGER_IAM_ROLE" | default "" }}
             # Enable the DNS-01 challenge provider
             - dns01:
-                route53: {}
-{{- end }}
-    - apiVersion: certmanager.k8s.io/v1alpha1
+                route53:
+                  region: {{ env "AWS_REGION" | default (env "AWS_DEFAULT_REGION") }}
+            {{- end }}
+    - apiVersion: cert-manager.io/v1
       kind: ClusterIssuer
       metadata:
         name: letsencrypt-prod
@@ -148,14 +143,16 @@ releases:
           privateKeySecretRef:
             name: letsencrypt-prod
           solvers:
+            {{- if env "CERT_MANAGER_HTTP_SOLVER_ENABLED" | default "" }}
             # Enable the HTTP-01 challenge provider
             - http01:
                 ingress:
                   class: nginx
-{{- if env "CERT_MANAGER_IAM_ROLE" | default "" }}
+            {{- end }}
+            {{- if env "CERT_MANAGER_IAM_ROLE" | default "" }}
             # Enable the DNS-01 challenge provider
             - dns01:
-                route53: {}
-{{- end }}
-
+                route53:
+                  region: {{ env "AWS_REGION" | default (env "AWS_DEFAULT_REGION") }}
+            {{- end }}
 

--- a/deprecated/cert-manager.yaml
+++ b/deprecated/cert-manager.yaml
@@ -4,7 +4,7 @@ repositories:
   url: "https://charts.jetstack.io"
   # Kubernetes incubator repo of helm charts
 - name: "kubernetes-incubator"
-  url: "https://kubernetes-charts-incubator.storage.googleapis.com"
+  url: "https://charts.helm.sh/incubator"
 
 releases:
 

--- a/deprecated/dashboard.yaml
+++ b/deprecated/dashboard.yaml
@@ -1,7 +1,7 @@
 repositories:
-# Stable repo of official helm charts
-- name: "stable"
-  url: "https://kubernetes-charts.storage.googleapis.com"
+# Official Kubernetes Dashboard helm chart
+- name: "kubernetes-dashboard"
+  url: "https://kubernetes.github.io/dashboard/"
 
 releases:
 
@@ -13,7 +13,7 @@ releases:
 #
 # References:
 #   - https://github.com/kubernetes/dashboard
-#   - https://github.com/kubernetes/charts/tree/master/stable/kubernetes-dashboard
+#   - https://github.com/kubernetes/dashboard/tree/master/aio/deploy/helm-chart/kubernetes-dashboard
 #
 - name: "kubernetes-dashboard"
   namespace: '{{- env "KUBERNETES_DASHBOARD_NAMESPACE" | default "kube-system" -}}'
@@ -24,26 +24,35 @@ releases:
     namespace: "kube-system"
     vendor: "kubernetes"
     default: "true"
-  chart: "stable/kubernetes-dashboard"
-  version: "0.10.0"
+  chart: "kubernetes-dashboard/kubernetes-dashboard"
+  version: '{{ env "KUBERNETES_DASHBOARD_CHART_VERSION" | default "v2.8.2" }}'
   wait: true
+  atomic: true
+  cleanupOnFail: true
   installed: {{ env "KUBERNETES_DASHBOARD_INSTALLED" | default "true" }}
   values:
     - image:
-        repository: "k8s.gcr.io/kubernetes-dashboard-amd64"
-        ### Optional: KUBERNETES_DASHBOARD_IMAGE_TAG;
-        tag: '{{ env "KUBERNETES_DASHBOARD_IMAGE_TAG" | default "v1.10.0" }}'
+        repository: "kubernetesui/dashboard"
+        ### Optional: KUBERNETES_DASHBOARD_IMAGE_TAG; use chart default otherwise
+        {{- if (env "KUBERNETES_DASHBOARD_IMAGE_TAG") }}
+        tag: '{{ env "KUBERNETES_DASHBOARD_IMAGE_TAG" }}'
+        {{- end }}
         pullPolicy: "IfNotPresent"
-      enableInsecureLogin: {{ env "KUBERNETES_DASHBOARD_ENABLE_INSECURE_LOGIN" | default "false"}}
-{{- if eq (env "KUBERNETES_DASHBOARD_ENABLE_INSECURE_LOGIN" | default "false") "true" }}
+      {{- if eq (env "KUBERNETES_DASHBOARD_ENABLE_INSECURE_LOGIN" | default "false") "true" }}
       service:
         externalPort: 80
-{{- end }}
-{{- if eq (env "KUBERNETES_DASHBOARD_SKIP_LOGIN" | default "false") "true" }}
+      {{- end }}
       extraArgs:
+        {{- if eq (env "KUBERNETES_DASHBOARD_ENABLE_INSECURE_LOGIN" | default "false") "true" }}
+        - --enable-insecure-login
+        {{- end }}
+        {{- if eq (env "KUBERNETES_DASHBOARD_SKIP_LOGIN" | default "false") "true" }}
         - --enable-skip-login
-{{- end }}
+        {{- end }}
       replicaCount: '{{ env "KUBERNETES_DASHBOARD_REPLICA_COUNT" | default 1 }}'
+      podDisruptionBudget:
+        enabled: true
+        maxUnavailable: "60%"
       resources:
         limits:
           cpu: '{{ env "KUBERNETES_DASHBOARD_LIMIT_CPU" | default "100m" }}'
@@ -53,10 +62,10 @@ releases:
           memory: '{{ env "KUBERNETES_DASHBOARD_REQUEST_MEMORY" | default "50Mi" }}'
       rbac:
         ### Optional: RBAC_ENABLED;
-        create: {{ env "RBAC_ENABLED" | default "false" }}
+        create: {{ env "RBAC_ENABLED" | default "true" }}
       serviceAccount:
         ### Optional: RBAC_ENABLED;
-        create: {{ env "RBAC_ENABLED" | default "false" }}
+        create: {{ env "RBAC_ENABLED" | default "true" }}
         ### Optional: KUBERNETES_DASHBOARD_SERVICE_ACCOUNT_NAME;
         name: '{{ env "KUBERNETES_DASHBOARD_SERVICE_ACCOUNT_NAME" | default "" }}'
 
@@ -64,15 +73,15 @@ releases:
         enabled: {{ env "KUBERNETES_DASHBOARD_INGRESS_ENABLED" | default "false" }}
         annotations:
           kubernetes.io/ingress.class: {{ env "KUBERNETES_DASHBOARD_INGRESS_CLASS" | default "nginx" }}
-{{- if eq (env "KUBERNETES_DASHBOARD_ENABLE_INSECURE_LOGIN" | default "false") "false" }}
+          {{- if eq (env "KUBERNETES_DASHBOARD_ENABLE_INSECURE_LOGIN" | default "false") "false" }}
           nginx.ingress.kubernetes.io/secure-backends: "true"
-{{- end }}
-          kubernetes.io/tls-acme: '{{ env "KUBERNETES_DASHBOARD_INGRESS_USE_KUBE_LEGO" | default "false" }}'
+          {{- end }}
+          kubernetes.io/tls-acme: '{{ env "KUBERNETES_DASHBOARD_INGRESS_USE_TLS_ACME" | default (env "KUBERNETES_DASHBOARD_INGRESS_TLS_ENABLED" | default "false") }}'
         hosts:
         - {{ env "KUBERNETES_DASHBOARD_INGRESS_HOST" }}
-{{- if eq (env "KUBERNETES_DASHBOARD_INGRESS_TLS_ENABLED" | default "false") "true" }}
+        {{- if eq (env "KUBERNETES_DASHBOARD_INGRESS_TLS_ENABLED" | default "false") "true" }}
         tls:
         - secretName: kubernetes-dashboard-tls
           hosts:
           - {{ env "KUBERNETES_DASHBOARD_INGRESS_HOST" }}
-{{- end }}
+        {{- end }}

--- a/deprecated/keycloak-gatekeeper.yaml
+++ b/deprecated/keycloak-gatekeeper.yaml
@@ -44,7 +44,7 @@ releases:
   chart: "gabibbo97/keycloak-gatekeeper"
   version: "3.3.1"
   wait: false
-  installed: true
+  installed: {{ not (index $service "uninstall") }}
   values:
   - nameOverride: "key-gate-{{- $service.name }}"
     fullNameOverride: "key-gate-{{- $service.name }}"

--- a/deprecated/kiam.yaml
+++ b/deprecated/kiam.yaml
@@ -34,12 +34,8 @@ releases:
 #   /bin/sh -c '/sbin/iptables -t nat -A PREROUTING -d 169.254.169.254/32 -i cali+ -p tcp -m tcp --dport 80 -j DNAT --to-destination $(curl -s http://169.254.169.254/latest/meta-data/local-ipv4):8181'
 #
 #
-# This release REQUIRES that cert-manager is installed and available, as it uses it to provision the
+# This release REQUIRES that cert-manager v1.x is installed and available, as it uses it to provision the
 # TLS certificates that secure the communication between the kiam agents and servers.
-#
-# WARNING: At this time, this release uses the outdated `certmanager.k8s.io/v1alpha1` cert-manager API
-# and not the v1 `cert-manager.io/v1` API. This is to provide a migration path for upgrading `kiam` before
-# upgrading `cert-manager`
 #
 # This release OPTIONALLY uses stakater/reloader, if installed,
 # to automatically restart kiam pods when the TLS certificates change
@@ -60,14 +56,14 @@ releases:
   installed: {{ env "KIAM_INSTALLED" | default "true" }}
   values:
     - resources:
-        - apiVersion: certmanager.k8s.io/v1alpha1
+        - apiVersion: cert-manager.io/v1
           kind: Issuer
           metadata:
             name: kiam-selfsigning-issuer
           spec:
             selfSigned: {}
 
-        - apiVersion: certmanager.k8s.io/v1alpha1
+        - apiVersion: cert-manager.io/v1
           kind: Certificate
           metadata:
             name: kiam-ca
@@ -78,7 +74,7 @@ releases:
             issuerRef:
               name: kiam-selfsigning-issuer
 
-        - apiVersion: certmanager.k8s.io/v1alpha1
+        - apiVersion: cert-manager.io/v1
           kind: Issuer
           metadata:
             name: kiam-ca-issuer
@@ -86,22 +82,30 @@ releases:
             ca:
               secretName: kiam-ca-tls
 
-        - apiVersion: certmanager.k8s.io/v1alpha1
+        - apiVersion: cert-manager.io/v1
           kind: Certificate
           metadata:
             name: kiam-agent
           spec:
             secretName: kiam-agent-tls
             commonName: agent
+            duration: 2160h # 90d
+            renewBefore: 360h # 15d
+            privateKey:
+              rotationPolicy: Always
             issuerRef:
               name: kiam-ca-issuer
 
-        - apiVersion: certmanager.k8s.io/v1alpha1
+        - apiVersion: cert-manager.io/v1
           kind: Certificate
           metadata:
             name: kiam-server
           spec:
             secretName: kiam-server-tls
+            duration: 2160h # 90d
+            renewBefore: 360h # 15d
+            privateKey:
+              rotationPolicy: Always
             issuerRef:
               name: kiam-ca-issuer
             dnsNames:
@@ -117,6 +121,7 @@ releases:
 # Here we deploy kiam itself
 # The release name must be "kiam" for chart to work properly with TLS/PKI certs
 - name: "kiam"
+  needs: ["kube-system/kiam-tls"]
   namespace: "kube-system"
   labels:
     chart: "kiam"

--- a/deprecated/kiam.yaml
+++ b/deprecated/kiam.yaml
@@ -4,7 +4,7 @@ repositories:
   url: "https://uswitch.github.io/kiam-helm-charts/charts/"
   # Kubernetes incubator repo of helm charts
 - name: "kubernetes-incubator"
-  url: "https://kubernetes-charts-incubator.storage.googleapis.com"
+  url: "https://charts.helm.sh/incubator"
 
   # Cloud Posse incubator repo of helm charts
 - name: "cloudposse-incubator"

--- a/deprecated/oidc-ingress.yaml
+++ b/deprecated/oidc-ingress.yaml
@@ -1,14 +1,14 @@
 repositories:
 # Repo of official, stable helm charts
 - name: "stable"
-  url: "https://kubernetes-charts.storage.googleapis.com"
+  url: "https://charts.helm.sh/stable"
 # keycloak-gatekeeper
 # No official chart, this user's chart seems to be the best there is
 - name: "gabibbo97"
   url: "https://gabibbo97.github.io/charts/"
 # Repo of new Kubernetes charts in development
 - name: "kubernetes-incubator"
-  url: "https://kubernetes-charts-incubator.storage.googleapis.com"
+  url: "https://charts.helm.sh/incubator"
 - name: "forecastle"
   # Cannot use release tags, see https://github.com/aslafy-z/helm-git/issues/9
   # url: "git+https://github.com/stakater/Forecastle@deployments/kubernetes/chart?ref=v1.0.25"


### PR DESCRIPTION
## what

- [deprecated/cert-manager] Upgrade to GA
- [deprecated/kiam] Upgrade to `cert-mangager` GA API
- [deprecated/dashbboard] Upgrade to chart v2 and new chart repo
- [deprecated/keycloak-gatekeeper.yaml] Add `uninstall` option

## why
- Upgrade [cert-manager](https://github.com/jetstack/cert-manager) and dependent release to stable V1 API
- Upgrade Kubernetes dashboard to support current Kubernetes versions
- Simply deleting a service from `keycloak-gatekeeper` configuration does not uninstall it, so add an uninstall option