### PR TITLE
Relocate stable and incubator official helm cart repos

### DIFF
--- a/deprecated/aws-alb-ingress-controller.yaml
+++ b/deprecated/aws-alb-ingress-controller.yaml
@@ -1,7 +1,7 @@
 repositories:
 # Incubator repo of official helm charts
 - name: "kubernetes-incubator"
-  url: "https://kubernetes-charts-incubator.storage.googleapis.com"
+  url: "https://charts.helm.sh/incubator"
 
 
 releases:

--- a/deprecated/chartmuseum-api.yaml
+++ b/deprecated/chartmuseum-api.yaml
@@ -1,7 +1,7 @@
 repositories:
 # Stable repo of official helm charts
 - name: "stable"
-  url: "https://kubernetes-charts.storage.googleapis.com"
+  url: "https://charts.helm.sh/stable"
 
 releases:
 

--- a/deprecated/chartmuseum.yaml
+++ b/deprecated/chartmuseum.yaml
@@ -1,7 +1,7 @@
 repositories:
 # Stable repo of official helm charts
 - name: "stable"
-  url: "https://kubernetes-charts.storage.googleapis.com"
+  url: "https://charts.helm.sh/stable"
 
 releases:
 

--- a/deprecated/cluster-autoscaler.yaml
+++ b/deprecated/cluster-autoscaler.yaml
@@ -1,7 +1,7 @@
 repositories:
 # Stable repo of official helm charts
 - name: "stable"
-  url: "https://kubernetes-charts.storage.googleapis.com"
+  url: "https://charts.helm.sh/stable"
 
 releases:
 

--- a/deprecated/codefresh-backup.yaml
+++ b/deprecated/codefresh-backup.yaml
@@ -1,7 +1,7 @@
 repositories:
 # Incubator repo of official helm charts
 - name: "kubernetes-incubator"
-  url: "https://kubernetes-charts-incubator.storage.googleapis.com/"
+  url: "https://charts.helm.sh/incubator/"
 
 releases:
 

--- a/deprecated/codefresh-extension.yaml
+++ b/deprecated/codefresh-extension.yaml
@@ -1,7 +1,7 @@
 repositories:
 # Incubator repo of official helm charts
 - name: "incubator"
-  url: "https://kubernetes-charts-incubator.storage.googleapis.com/"
+  url: "https://charts.helm.sh/incubator/"
 
 releases:
 

--- a/deprecated/codefresh-restore.yaml
+++ b/deprecated/codefresh-restore.yaml
@@ -1,7 +1,7 @@
 repositories:
 # Incubator repo of official helm charts
 - name: "kubernetes-incubator"
-  url: "https://kubernetes-charts-incubator.storage.googleapis.com/"
+  url: "https://charts.helm.sh/incubator/"
 
 releases:
 

--- a/deprecated/efs-provisioner.yaml
+++ b/deprecated/efs-provisioner.yaml
@@ -1,7 +1,7 @@
 repositories:
 # Stable repo of official helm charts
 - name: "stable"
-  url: "https://kubernetes-charts.storage.googleapis.com"
+  url: "https://charts.helm.sh/stable"
 
 releases:
 

--- a/deprecated/elasticsearch-exporter.yaml
+++ b/deprecated/elasticsearch-exporter.yaml
@@ -1,7 +1,7 @@
 repositories:
   # Stable repo of official helm charts
   - name: "stable"
-    url: "https://kubernetes-charts.storage.googleapis.com"
+    url: "https://charts.helm.sh/stable"
 
 releases:
 

--- a/deprecated/external-storage.yaml
+++ b/deprecated/external-storage.yaml
@@ -1,7 +1,7 @@
 repositories:
 # Kubernetes incubator repo of helm charts
 - name: "kubernetes-incubator"
-  url: "https://kubernetes-charts-incubator.storage.googleapis.com"
+  url: "https://charts.helm.sh/incubator"
 
 releases:
 #

--- a/deprecated/grafana-dashboards.yaml
+++ b/deprecated/grafana-dashboards.yaml
@@ -1,7 +1,7 @@
 repositories:
   # Kubernetes incubator repo of helm charts
   - name: "kubernetes-incubator"
-    url: "https://kubernetes-charts-incubator.storage.googleapis.com"
+    url: "https://charts.helm.sh/incubator"
 
 ######
 # You need to create a grafana-dashboards-definitions.yaml file with an array of

--- a/deprecated/grafana.yaml
+++ b/deprecated/grafana.yaml
@@ -1,7 +1,7 @@
 repositories:
 # Stable repo of official helm charts
 - name: "stable"
-  url: "https://kubernetes-charts.storage.googleapis.com"
+  url: "https://charts.helm.sh/stable"
 
 releases:
 

--- a/deprecated/heapster.yaml
+++ b/deprecated/heapster.yaml
@@ -1,7 +1,7 @@
 repositories:
 # Stable repo of official helm charts
 - name: "stable"
-  url: "https://kubernetes-charts.storage.googleapis.com"
+  url: "https://charts.helm.sh/stable"
 
 releases:
 

--- a/deprecated/istio-gatekeeper.yaml
+++ b/deprecated/istio-gatekeeper.yaml
@@ -1,14 +1,14 @@
 repositories:
 # Repo of official, stable helm charts
 - name: "stable"
-  url: "https://kubernetes-charts.storage.googleapis.com"
+  url: "https://charts.helm.sh/stable"
 # keycloak-gatekeeper
 # No official chart, this user's chart seems to be the best there is
 - name: "gabibbo97"
   url: "https://gabibbo97.github.io/charts/"
 # Repo of new Kubernetes charts in development
 - name: "kubernetes-incubator"
-  url: "https://kubernetes-charts-incubator.storage.googleapis.com"
+  url: "https://charts.helm.sh/incubator"
 # Forecastle does not have a chart in a helm repo. Use plugin to pull the chart from GitHub repo
 - name: "forecastle"
   # Cannot use release tags, see https://github.com/aslafy-z/helm-git/issues/9

--- a/deprecated/istio.yaml
+++ b/deprecated/istio.yaml
@@ -4,7 +4,7 @@ repositories:
 
   # Kubernetes incubator repo of helm charts
   - name: "kubernetes-incubator"
-    url: "https://kubernetes-charts-incubator.storage.googleapis.com"
+    url: "https://charts.helm.sh/incubator"
 
   # Cloud Posse incubator repo of helm charts
   - name: "cloudposse-incubator"

--- a/deprecated/kibana-elastic-search.yaml
+++ b/deprecated/kibana-elastic-search.yaml
@@ -1,7 +1,7 @@
 repositories:
 # Incubator repo of official helm charts
 - name: "kubernetes-incubator"
-  url: "https://kubernetes-charts-incubator.storage.googleapis.com/"
+  url: "https://charts.helm.sh/incubator/"
 
 releases:
 

--- a/deprecated/kibana.yaml
+++ b/deprecated/kibana.yaml
@@ -1,7 +1,7 @@
 repositories:
 # Stable repo of official helm charts
 - name: "stable"
-  url: "https://kubernetes-charts.storage.googleapis.com"
+  url: "https://charts.helm.sh/stable"
 
 releases:
 

--- a/deprecated/kube-lego.yaml
+++ b/deprecated/kube-lego.yaml
@@ -1,7 +1,7 @@
 repositories:
 # Stable repo of official helm charts
 - name: "stable"
-  url: "https://kubernetes-charts.storage.googleapis.com"
+  url: "https://charts.helm.sh/stable"
 
 
 releases:

--- a/deprecated/kube2iam.yaml
+++ b/deprecated/kube2iam.yaml
@@ -1,7 +1,7 @@
 repositories:
 # Stable repo of official helm charts
 - name: "stable"
-  url: "https://kubernetes-charts.storage.googleapis.com"
+  url: "https://charts.helm.sh/stable"
 
 releases:
 

--- a/deprecated/kubecost.yaml
+++ b/deprecated/kubecost.yaml
@@ -4,7 +4,7 @@ repositories:
     url: "https://kubecost.github.io/cost-analyzer/"
   # Kubernetes incubator repo of helm charts
   - name: "kubernetes-incubator"
-    url: "https://kubernetes-charts-incubator.storage.googleapis.com"
+    url: "https://charts.helm.sh/incubator"
 
 releases:
   #######################################################################################

--- a/deprecated/lighthouse-ci.yaml
+++ b/deprecated/lighthouse-ci.yaml
@@ -1,7 +1,7 @@
 repositories:
 # Stable repo of official helm charts
 - name: "stable"
-  url: "https://kubernetes-charts.storage.googleapis.com"
+  url: "https://charts.helm.sh/stable"
 # Cloud Posse incubator repo of helm charts
 - name: "cloudposse-incubator"
   url: "https://charts.cloudposse.com/incubator/"

--- a/deprecated/metrics-server.yaml
+++ b/deprecated/metrics-server.yaml
@@ -1,7 +1,7 @@
 repositories:
 # Stable repo of official helm charts
 - name: "stable"
-  url: "https://kubernetes-charts.storage.googleapis.com"
+  url: "https://charts.helm.sh/stable"
 
 releases:
 

--- a/deprecated/nginx-ingress.yaml
+++ b/deprecated/nginx-ingress.yaml
@@ -1,7 +1,7 @@
 repositories:
 # Stable repo of official helm charts
 - name: "stable"
-  url: "https://kubernetes-charts.storage.googleapis.com"
+  url: "https://charts.helm.sh/stable"
 # Cloud Posse incubator repo of helm charts
 - name: "cloudposse-incubator"
   url: "https://charts.cloudposse.com/incubator/"

--- a/deprecated/oidc-role.yaml
+++ b/deprecated/oidc-role.yaml
@@ -1,7 +1,7 @@
 repositories:
 # Kubernetes incubator repo of helm charts
 - name: "kubernetes-incubator"
-  url: "https://kubernetes-charts-incubator.storage.googleapis.com"
+  url: "https://charts.helm.sh/incubator"
 
 releases:
 #######################################################################################

--- a/deprecated/phpmyadmin.yaml
+++ b/deprecated/phpmyadmin.yaml
@@ -1,7 +1,7 @@
 repositories:
   # Stable repo of official helm charts
   - name: "stable"
-    url: "https://kubernetes-charts.storage.googleapis.com"
+    url: "https://charts.helm.sh/stable"
 
 releases:
 

--- a/deprecated/pritunl.yaml
+++ b/deprecated/pritunl.yaml
@@ -1,7 +1,7 @@
 repositories:
 # Stable repo of official helm charts
 - name: "stable"
-  url: "https://kubernetes-charts.storage.googleapis.com"
+  url: "https://charts.helm.sh/stable"
 # Cloud Posse incubator repo of helm charts
 - name: "cloudposse-incubator"
   url: "https://charts.cloudposse.com/incubator/"

--- a/deprecated/prometheus-cloudwatch-exporter.yaml
+++ b/deprecated/prometheus-cloudwatch-exporter.yaml
@@ -1,7 +1,7 @@
 repositories:
   # Stable repo of official helm charts
   - name: "stable"
-    url: "https://kubernetes-charts.storage.googleapis.com"
+    url: "https://charts.helm.sh/stable"
 
 releases:
 

--- a/deprecated/prometheus-operator.yaml
+++ b/deprecated/prometheus-operator.yaml
@@ -14,7 +14,7 @@
 repositories:
   # Official helm charts
   - name: "stable"
-    url: "https://kubernetes-charts.storage.googleapis.com/"
+    url: "https://charts.helm.sh/stable/"
 
 releases:
 

--- a/deprecated/prometheus-pushgateway.yaml
+++ b/deprecated/prometheus-pushgateway.yaml
@@ -1,7 +1,7 @@
 repositories:
   # Stable repo of official helm charts
   - name: "stable"
-    url: "https://kubernetes-charts.storage.googleapis.com"
+    url: "https://charts.helm.sh/stable"
 
 releases:
   ########################################################################

--- a/deprecated/sentry-kubernetes.yaml
+++ b/deprecated/sentry-kubernetes.yaml
@@ -1,7 +1,7 @@
 repositories:
   # Repo of new Kubernetes charts in development
   - name: "kubernetes-incubator"
-    url: "https://kubernetes-charts-incubator.storage.googleapis.com"
+    url: "https://charts.helm.sh/incubator"
 
 releases:
 

--- a/deprecated/sentry.yaml
+++ b/deprecated/sentry.yaml
@@ -1,7 +1,7 @@
 repositories:
   # Stable repo of official helm charts
   - name: "stable"
-    url: "https://kubernetes-charts.storage.googleapis.com"
+    url: "https://charts.helm.sh/stable"
   # Cloud Posse incubator repo of helm charts
   - name: "cloudposse-incubator"
     url: "https://charts.cloudposse.com/incubator/"

--- a/deprecated/storage-classes.yaml
+++ b/deprecated/storage-classes.yaml
@@ -1,7 +1,7 @@
 repositories:
 # Kubernetes incubator repo of helm charts
 - name: "kubernetes-incubator"
-  url: "https://kubernetes-charts-incubator.storage.googleapis.com"
+  url: "https://charts.helm.sh/incubator"
 
 releases:
 # Define some StorageClasses for use in PersistentVolumeClaims

--- a/deprecated/traefik-ingress.yaml
+++ b/deprecated/traefik-ingress.yaml
@@ -1,7 +1,7 @@
 repositories:
 # Stable repo of official helm charts
 - name: "stable"
-  url: "https://kubernetes-charts.storage.googleapis.com"
+  url: "https://charts.helm.sh/stable"
 # Cloud Posse incubator repo of helm charts
 - name: "cloudposse-incubator"
   url: "https://charts.cloudposse.com/incubator/"

--- a/releases/cert-manager/helmfile.yaml
+++ b/releases/cert-manager/helmfile.yaml
@@ -4,7 +4,7 @@ repositories:
     url: "https://charts.jetstack.io"
     # Kubernetes incubator repo of helm charts
   - name: "kubernetes-incubator"
-    url: "https://kubernetes-charts-incubator.storage.googleapis.com"
+    url: "https://charts.helm.sh/incubator"
 
 releases:
 

--- a/releases/cluster-autoscaler/helmfile.yaml
+++ b/releases/cluster-autoscaler/helmfile.yaml
@@ -1,7 +1,7 @@
 repositories:
   # Stable repo of official helm charts
   - name: "stable"
-    url: "https://kubernetes-charts.storage.googleapis.com"
+    url: "https://charts.helm.sh/stable"
 
 releases:
 

--- a/releases/datadog/helmfile.yaml
+++ b/releases/datadog/helmfile.yaml
@@ -1,10 +1,10 @@
 repositories:
   # Stable repo of official helm charts
   - name: "stable"
-    url: "https://kubernetes-charts.storage.googleapis.com"
+    url: "https://charts.helm.sh/stable"
   # Kubernetes incubator repo of helm charts
   - name: "kubernetes-incubator"
-    url: "https://kubernetes-charts-incubator.storage.googleapis.com"
+    url: "https://charts.helm.sh/incubator"
 
 releases:
 # Use Kubernetes "raw" chart to create aws-secret-operator secrets

--- a/releases/efs-provisioner/helmfile.yaml
+++ b/releases/efs-provisioner/helmfile.yaml
@@ -1,7 +1,7 @@
 repositories:
 # Stable repo of official helm charts
 - name: "stable"
-  url: "https://kubernetes-charts.storage.googleapis.com"
+  url: "https://charts.helm.sh/stable"
 
 releases:
 

--- a/releases/idp-roles/helmfile.yaml
+++ b/releases/idp-roles/helmfile.yaml
@@ -1,7 +1,7 @@
 repositories:
 # Kubernetes incubator repo of helm charts
 - name: "kubernetes-incubator"
-  url: "https://kubernetes-charts-incubator.storage.googleapis.com"
+  url: "https://charts.helm.sh/incubator"
 
 releases:
 

--- a/releases/keycloak-gatekeeper/helmfile.yaml
+++ b/releases/keycloak-gatekeeper/helmfile.yaml
@@ -5,7 +5,7 @@ repositories:
   url: "https://gabibbo97.github.io/charts/"
 # Kubernetes incubator repo of helm charts
 - name: "kubernetes-incubator"
-  url: "https://kubernetes-charts-incubator.storage.googleapis.com"
+  url: "https://charts.helm.sh/incubator"
 
 releases:
 

--- a/releases/kubernetes-dashboard/helmfile.yaml
+++ b/releases/kubernetes-dashboard/helmfile.yaml
@@ -1,7 +1,7 @@
 repositories:
 # Stable repo of official helm charts
 - name: "stable"
-  url: "https://kubernetes-charts.storage.googleapis.com"
+  url: "https://charts.helm.sh/stable"
 
 releases:
 

--- a/releases/metrics-server/helmfile.yaml
+++ b/releases/metrics-server/helmfile.yaml
@@ -2,7 +2,7 @@ repositories:
 # Stable repo of official helm charts, deprecated, but no official replacement yet.
 # Possibly use https://charts.bitnami.com/bitnami but it is different chart
 - name: "stable"
-  url: "https://kubernetes-charts.storage.googleapis.com"
+  url: "https://charts.helm.sh/stable"
 
 releases:
 

--- a/releases/nginx-ingress/helmfile.yaml
+++ b/releases/nginx-ingress/helmfile.yaml
@@ -1,7 +1,7 @@
 repositories:
 # Stable repo of official helm charts
 - name: "stable"
-  url: "https://kubernetes-charts.storage.googleapis.com"
+  url: "https://charts.helm.sh/stable"
   # Cloud Posse incubator repo of helm charts
 - name: "cloudposse-incubator"
   url: "https://charts.cloudposse.com/incubator/"

--- a/releases/oidc-ingress/helmfile.yaml
+++ b/releases/oidc-ingress/helmfile.yaml
@@ -1,14 +1,14 @@
 repositories:
 # Repo of official, stable helm charts
 - name: "stable"
-  url: "https://kubernetes-charts.storage.googleapis.com"
+  url: "https://charts.helm.sh/stable"
 # keycloak-gatekeeper
 # No official chart, this user's chart seems to be the best there is
 - name: "gabibbo97"
   url: "https://gabibbo97.github.io/charts/"
 # Repo of new Kubernetes charts in development
 - name: "kubernetes-incubator"
-  url: "https://kubernetes-charts-incubator.storage.googleapis.com"
+  url: "https://charts.helm.sh/incubator"
 - name: "forecastle"
   # Cannot use release tags, see https://github.com/aslafy-z/helm-git/issues/9
   # Starting with git version 2.22, you also need to append &sparse=0 at the end

--- a/releases/oidc-role/helmfile.yaml
+++ b/releases/oidc-role/helmfile.yaml
@@ -1,7 +1,7 @@
 repositories:
 # Kubernetes incubator repo of helm charts
 - name: "kubernetes-incubator"
-  url: "https://kubernetes-charts-incubator.storage.googleapis.com"
+  url: "https://charts.helm.sh/incubator"
 
 releases:
 

--- a/releases/sentry-kubernetes/helmfile.yaml
+++ b/releases/sentry-kubernetes/helmfile.yaml
@@ -1,6 +1,6 @@
 repositories:
   - name: "kubernetes-incubator"
-    url: "https://kubernetes-charts-incubator.storage.googleapis.com"
+    url: "https://charts.helm.sh/incubator"
 
 releases:
   - name: "sentry-kubernetes"


### PR DESCRIPTION
## what

- Relocate stable and incubator official helm chart repos to archives

## why

- Historic locations are no longer available

## references

- [Deprecation timeline](https://github.com/helm/charts/blob/master/README.md#deprecation-timeline) for official Helm Stable and Incubator repos
- New repos for specific "stable" charts are being tracked [here](https://github.com/helm/charts/issues/21103)
- Helm [documentation about chart archives](https://helm.sh/docs/faq/#i-am-getting-a-warning-about-unable-to-get-an-update-from-the-stable-chart-repository)

