### PR TITLE
Fix ClusterAgent section

### DIFF
--- a/releases/datadog/helmfile.yaml
+++ b/releases/datadog/helmfile.yaml
@@ -91,10 +91,10 @@ releases:
         processCollection: {{ .Values.processAgent.enabled }}
       systemProbe:
         enabled: {{ .Values.systemProbe.enabled }}
-      clusterAgent:
-        enabled: {{ .Values.clusterAgent.enabled }}
-        tokenExistingSecret: {{ .Values.clusterTokenSecret.name }}
-        metricsProvider:
-          enabled: {{ .Values.metricsProvider.enabled }}
-        clusterChecks:
-          enabled: {{ .Values.clusterChecks.enabled }}
+    clusterAgent:
+      enabled: {{ .Values.clusterAgent.enabled }}
+      tokenExistingSecret: {{ .Values.clusterTokenSecret.name }}
+      metricsProvider:
+        enabled: {{ .Values.metricsProvider.enabled }}
+      clusterChecks:
+        enabled: {{ .Values.clusterChecks.enabled }}


### PR DESCRIPTION
## what
* DataDog ClusterAgent was not installing properly

## why
* Extra spacing put the cluserAgent section under Values.datadog instead of directly at the root



