### PR TITLE
Use '%012d' for accountId instead of '%v'

### DIFF
--- a/releases/autoscaler/helmfile.yaml
+++ b/releases/autoscaler/helmfile.yaml
@@ -57,7 +57,7 @@ releases:
           ## Annotations for the Service Account
           {{- if .Values.provider | eq "aws" }}
           annotations:
-            eks.amazonaws.com/role-arn: {{ printf "arn:aws:iam::%v:role/%v-%v-%v-eks-%v@kube-system" .Values.account_number .Values.namespace .Values.environment .Values.stage .Values.service_account_name | quote }}
+            eks.amazonaws.com/role-arn: {{ printf "arn:aws:iam::%012d:role/%v-%v-%v-eks-%v@kube-system" .Values.account_number .Values.namespace .Values.environment .Values.stage .Values.service_account_name | quote }}
           {{- end }}
         ## Podsecuritypolicy
         pspEnabled: false

--- a/releases/cert-manager/helmfile.yaml
+++ b/releases/cert-manager/helmfile.yaml
@@ -67,7 +67,7 @@ releases:
         name: "cert-manager"
         # https://github.com/jetstack/cert-manager/blob/master/deploy/charts/cert-manager/templates/serviceaccount.yaml
         annotations:
-          eks.amazonaws.com/role-arn: {{ printf "arn:aws:iam::%v:role/%v-%v-%v-eks-cert-manager" .Values.account_number .Values.namespace .Values.environment .Values.stage | quote }}
+          eks.amazonaws.com/role-arn: {{ printf "arn:aws:iam::%012d:role/%v-%v-%v-eks-cert-manager" .Values.account_number .Values.namespace .Values.environment .Values.stage | quote }}
       securityContext:
         enabled: true
         fsGroup: 1001

--- a/releases/codefresh-runners/helmfile.yaml
+++ b/releases/codefresh-runners/helmfile.yaml
@@ -28,7 +28,7 @@ releases:
         - "-c"
         - >-
           kubectl get namespace "{{`{{ .Release.Namespace }}`}}" >/dev/null 2>&1 || kubectl create namespace "{{`{{ .Release.Namespace }}`}}";
-          kubectl annotate -n "{{`{{ .Release.Namespace }}`}}" sa --overwrite default eks.amazonaws.com/role-arn={{ printf "arn:aws:iam::%v:role/%v-%v-%v-eks-default@codefresh-%v" $.Values.account_number $.Values.namespace $.Values.environment $.Values.stage $runner | quote }};
+          kubectl annotate -n "{{`{{ .Release.Namespace }}`}}" sa --overwrite default eks.amazonaws.com/role-arn={{ printf "arn:aws:iam::%012d:role/%v-%v-%v-eks-default@codefresh-%v" $.Values.account_number $.Values.namespace $.Values.environment $.Values.stage $runner | quote }};
 {{- end }}
   values:
     - env:

--- a/releases/external-dns/helmfile.yaml
+++ b/releases/external-dns/helmfile.yaml
@@ -67,7 +67,7 @@ releases:
         ## Annotations for the Service Account
         {{- if .Values.provider | eq "aws" }}
         annotations:
-          eks.amazonaws.com/role-arn: {{ printf "arn:aws:iam::%v:role/%v-%v-%v-eks-%v@kube-system" .Values.account_number .Values.namespace .Values.environment .Values.stage .Values.service_account_name | quote }}
+          eks.amazonaws.com/role-arn: {{ printf "arn:aws:iam::%012d:role/%v-%v-%v-eks-%v@kube-system" .Values.account_number .Values.namespace .Values.environment .Values.stage .Values.service_account_name | quote }}
         {{- end }}
       aws:
         region: {{ .Values.region | quote }}

--- a/releases/fluentd/helmfile.yaml
+++ b/releases/fluentd/helmfile.yaml
@@ -67,7 +67,7 @@ releases:
       enabled: true
       name: fluentd
       annotations:
-        eks.amazonaws.com/role-arn: "{{ printf "arn:aws:iam::%v:role/%v-%v-%v-eks-fluentd@kube-system" .Values.account_number .Values.namespace .Values.environment .Values.stage }}"
+        eks.amazonaws.com/role-arn: "{{ printf "arn:aws:iam::%012d:role/%v-%v-%v-eks-fluentd@kube-system" .Values.account_number .Values.namespace .Values.environment .Values.stage }}"
 
     serviceMonitor:
       # Enable the service monitor when we find or create a Grafana dashboard to display the metrics


### PR DESCRIPTION
## what

- Use `%012d` for the AWS `accountId` instead of `%v` in ARN representations.

## why

From [https://pkg.go.dev/fmt](https://pkg.go.dev/fmt)

> `%v	the value in a default format`

In the case of the AWS `accountId` the default format was a number meaning leading zeros are removed, meaning `0123456789` becomes `123456789` resulting in an incorrect role name. 

## References

https://docs.aws.amazon.com/general/latest/gr/acct-identifiers.html
