### PR TITLE
git.io->cloudposse.tools update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ export DOCKER_TAG ?= latest
 export DOCKER_IMAGE_NAME ?= $(DOCKER_IMAGE):$(DOCKER_TAG)
 export DOCKER_BUILD_FLAGS = 
 export README_DEPS ?= docs/targets.md
--include $(shell curl -sSL -o .build-harness "https://git.io/build-harness"; echo .build-harness)
+-include $(shell curl -sSL -o .build-harness "https://cloudposse.tools/build-harness"; echo .build-harness)
 
 all: init deps build install run
 


### PR DESCRIPTION
## what and why 
Change all references to `git.io/build-harness` into `cloudposse.tools/build-harness`, since `git.io` redirects will stop working on April 29th, 2022.

## References
- DEV-143